### PR TITLE
Filepath typos in situational_awareness/host modules

### DIFF
--- a/lib/modules/situational_awareness/host/computerdetails.py
+++ b/lib/modules/situational_awareness/host/computerdetails.py
@@ -76,7 +76,7 @@ class Module:
     def generate(self):
 
         # read in the common module source code
-        moduleSource = self.mainMenu.installPath + "/data/module_source/situational_awareness/Host/Get-ComputerDetails.ps1"
+        moduleSource = self.mainMenu.installPath + "/data/module_source/situational_awareness/host/Get-ComputerDetails.ps1"
 
         try:
             f = open(moduleSource, 'r')

--- a/lib/modules/situational_awareness/host/winenum.py
+++ b/lib/modules/situational_awareness/host/winenum.py
@@ -71,7 +71,7 @@ class Module:
     def generate(self):
 
         # read in the common module source code
-        moduleSource = self.mainMenu.installPath + "/data/module_source/situational_awareness/Host/Invoke-WinEnum.ps1"
+        moduleSource = self.mainMenu.installPath + "/data/module_source/situational_awareness/host/Invoke-WinEnum.ps1"
 
         try:
             f = open(moduleSource, 'r')


### PR DESCRIPTION
Caught a couple instances of "Host" being used to make the filepath instead of "host", causing Empire to not load the referenced PS1 file.