### PR TITLE
Use authenticated encryption

### DIFF
--- a/lib/common/agents.py
+++ b/lib/common/agents.py
@@ -1035,7 +1035,7 @@ class Agents:
                     sessionKey = self.agents[sessionID][0]
 
                     # encrypt the tasking packets with the agent's session key
-                    encryptedData = encryption.aes_encrypt(sessionKey, allTaskPackets)
+                    encryptedData = encryption.aes_encrypt_then_mac(sessionKey, allTaskPackets)
 
                     return (200, encryptedData)
 
@@ -1112,8 +1112,8 @@ class Agents:
                 sessionKey = self.agents[sessionID][0]
 
                 try:
-                    # decrypt and depad the packet
-                    packet = encryption.aes_decrypt(sessionKey, postData)
+                    # verify, decrypt and depad the packet
+                    packet = encryption.aes_decrypt_and_verify(sessionKey, postData)
 
                     # update the client's last seen time
                     self.update_agent_lastseen(sessionID)

--- a/lib/common/encryption.py
+++ b/lib/common/encryption.py
@@ -9,7 +9,7 @@ from Crypto.Cipher import AES
 from Crypto import Random
 from Crypto.Random import random
 from binascii import hexlify 
-import base64, string, M2Crypto
+import base64, hashlib, hmac, string, M2Crypto
 
 import helpers
 
@@ -71,6 +71,15 @@ def aes_encrypt(key, data):
     return IV + cipher.encrypt(pad(data))
 
 
+def aes_encrypt_then_mac(key, data):
+    """
+    Encrypt the data then calculate HMAC over the ciphertext.
+    """
+    data = aes_encrypt(key, data)
+    mac = hmac.new(str(key), data, hashlib.md5).digest()
+    return data + mac
+
+
 def aes_decrypt(key, data):
     """
     Generate an AES cipher object, pull out the IV from the data
@@ -80,6 +89,31 @@ def aes_decrypt(key, data):
         IV = data[0:16]
         cipher = AES.new(key, AES.MODE_CBC, IV)
         return depad(cipher.decrypt(data[16:]))
+
+
+def verify_hmac(key, data):
+    """
+    Verify the HMAC supplied in the data with the given key.
+    """
+    if len(data) > 16:
+        mac = data[-16:]
+        data = data[:-16]
+        expected = hmac.new(str(key), data, hashlib.md5).digest()
+        # Double HMAC to prevent timing attacks. hmac.compare_digest() is
+        # preferable, but only available since Python 2.7.7.
+        return hmac.new(str(key), expected).digest() == hmac.new(str(key), mac).digest()
+
+    return False
+
+
+def aes_decrypt_and_verify(key, data):
+    """
+    Decrypt the data, but only if it has a valid MAC.
+    """
+    if len(data) > 32 and verify_hmac(key, data):
+        return aes_decrypt(key, data[:-16])
+
+    raise Exception("Invalid ciphertext received.")
 
 
 def generate_aes_key():


### PR DESCRIPTION
Even though the agent to server communications are encrypted they are still malleable and vulnerable to attack.

The easiest attack is to trick a server into forgetting an agent. Take an encrypted message sniffed from the network and send it to the server 256 times with the first byte replaced so that it has all values 0 through 255. The server sees 256 packets with 256 different types, one is guaranteed to be `TASK_EXIT`.

Because the padding isn't verified there isn't an opportunity for a traditional padding oracle attack. However, there are ways to get the server to decrypt portions of an encrypted packet for you. The only method for doing this I've worked out isn't very efficient or effective though.

Notes some choices I made:

* MD5 to save space in messages over something better, e.g. SHA256
* Double HMAC to prevent timing attacks on the server. Python provides a `compare_digest()` method but it was only introduced in 2.7.7 (Kali is currently 2.7.3)

This should also probably be extended to the stager. I can do that in a follow up commit if somebody signs off on my powershell looking sane :)

I've only given some cursory testing with basic functionality as I haven't had an opportunity to get familiar with Empire.