### PR TITLE
International support

### DIFF
--- a/changelog
+++ b/changelog
@@ -6,6 +6,7 @@
 -Added credential parsing for dcsync output
 -updated links for PowerTools
 -Fixed bug in credential parsing with ":" inside of the password,username, or domain
+-Fixed international locale bug with unicode text in agent.ps1. Now all results are base64 encoded prior to being packetized. Encoding will be handled at server.
 
 8/20/2015
 ---------

--- a/data/agent/agent.ps1
+++ b/data/agent/agent.ps1
@@ -565,6 +565,9 @@ function Invoke-Empire {
             $data = $data -join "`n"
         }
         
+        #convert data to base64 so we can support all encodings and handle on server side
+        $data = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.getbytes($data))
+
         $packet = New-Object Byte[] (12 + $data.Length)
 
         # calculate the counter = epochDiff from server + current epoch

--- a/lib/common/packets.py
+++ b/lib/common/packets.py
@@ -23,7 +23,7 @@ builds tasking packets and parses result packets
 """
 
 
-import struct, time
+import struct, time, base64
 
 
 # 0         -> error
@@ -117,7 +117,11 @@ def parse_result_packet(packet, offset=0):
         responseID = struct.unpack('=L', packet[0+offset:4+offset])[0]
         counter = struct.unpack('=L', packet[4+offset:8+offset])[0]
         length = struct.unpack('=L', packet[8+offset:12+offset])[0]
-        data = packet[12+offset:12+offset+length]
+        data = base64.b64decode(packet[12+offset:12+offset+length])
+        #if isinstance(data, unicode):
+        #    print "UNICODE DATA"
+        #elif isinstance(data, str):
+        #    print "ASCII / UTF8"
         remainingData = packet[12+offset+length:]
         return (PACKET_IDS[responseID], counter, length, data, remainingData)
     except:


### PR DESCRIPTION
Made results get returned base64 so that agent.ps1 works independent of unicode chars in output. Will need revisiting for full unicode output support. 