### PR TITLE
Fixed module template to reflect required OutputExtension parameter

### DIFF
--- a/lib/modules/template.py
+++ b/lib/modules/template.py
@@ -19,8 +19,8 @@ class Module:
             # True if the module needs to run in the background
             'Background' : False,
 
-            # True if we're saving the output as a file
-            'SaveOutput' : True,
+            # File extension to save the screenshot as
+            'OutputExtension' : None,
 
             # True if the module needs admin rights to run
             'NeedsAdmin' : False,


### PR DESCRIPTION
Was messing around with module dev earlier and ran across this while using template.py 

(Empire: situational_awareness/host/paranoia) > info

           Name: Invoke-Paranoia
         Module: situational_awareness/host/paranoia
     NeedsAdmin: True
      OpsecSafe: True
   MinPSVersion: 2
     Background: True
Traceback (most recent call last):
  File "./empire", line 20, in <module>
    main.cmdloop()
  File "/home/pasv/Empire/lib/common/empire.py", line 183, in cmdloop
    cmd.Cmd.cmdloop(self)
  File "/usr/lib/python2.7/cmd.py", line 142, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python2.7/cmd.py", line 221, in onecmd
    return func(arg)
  File "/home/pasv/Empire/lib/common/empire.py", line 285, in do_agents
    a.cmdloop()
  File "/usr/lib/python2.7/cmd.py", line 142, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python2.7/cmd.py", line 221, in onecmd
    return func(arg)
  File "/home/pasv/Empire/lib/common/empire.py", line 719, in do_interact
    a.cmdloop()
  File "/usr/lib/python2.7/cmd.py", line 142, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python2.7/cmd.py", line 221, in onecmd
    return func(arg)
  File "/home/pasv/Empire/lib/common/empire.py", line 1545, in do_usemodule
    l.cmdloop()
  File "/usr/lib/python2.7/cmd.py", line 142, in cmdloop
    stop = self.onecmd(line)
  File "/usr/lib/python2.7/cmd.py", line 221, in onecmd
    return func(arg)
  File "/home/pasv/Empire/lib/common/empire.py", line 2295, in do_info
    messages.display_module(self.moduleName, self.module)
  File "/home/pasv/Empire/lib/common/messages.py", line 370, in display_module
    print '{0: >17}'.format("OutputExtension: ") + (str(module.info['OutputExtension']) if module.info['OutputExtension'] else "None")
KeyError: 'OutputExtension'
