### PR TITLE
Specifying Mandatory Level SID at Invoke-BypassUAC

### DIFF
--- a/data/module_source/privesc/Invoke-BypassUAC.ps1
+++ b/data/module_source/privesc/Invoke-BypassUAC.ps1
@@ -84,7 +84,7 @@ function Invoke-BypassUAC
         "[!] Current user not a local administrator!"
         Throw ("Current user not a local administrator!")
     }
-    if (($(whoami /groups) -like "*Medium Mandatory Level*").length -eq 0) {
+    if (($(whoami /groups) -like "*S-1-16-8192*").length -eq 0) {
         "[!] Not in a medium integrity process!"
         Throw ("Not in a medium integrity process!")
     }


### PR DESCRIPTION
Specifying Mandatory Level Name instead of SID can lead to false-negative result (for non-latin names, as for me - cyrillic). Changed to SID

![2015-11-02 00 02 38](https://cloud.githubusercontent.com/assets/3201035/10871341/495d1dca-80f5-11e5-95d5-d42abbdd4382.png)
