### PR TITLE
Non-interactive install

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -1,15 +1,38 @@
 #!/bin/bash
 
-apt-get install python-pip
+SCRIPT="$(readlink -f ${BASH_SOURCE[0]})"
+DIR="$(dirname $SCRIPT)"
+echo $DIR
 
-#ubuntu 14.04 LTS dependencies
-apt-get install python-dev
-apt-get install python-m2crypto
-apt-get install swig
-pip install pycrypto
+if getopts ":y" opt; then
+    case $opt in
+        y)
+            apt-get install python-pip -y
+            apt-get install python-dev -y
+            apt-get install python-m2crypto -y
+            apt-get install swig -y
+            pip install pycrypto
+            pip install iptools
+            pip install pydispatcher
+	
+            $DIR/setup_database.py -y
+        ;;
+    esac
+else
 
-#kali dependencies
-pip install iptools
-pip install pydispatcher
+    apt-get install python-pip
 
-./setup_database.py
+    # Ubuntu 14.04 LTS dependencies
+    apt-get install python-dev
+    apt-get install python-m2crypto
+    apt-get install swig
+    pip install pycrypto
+
+    # Kali Dependencies
+    pip install iptools
+    pip install pydispatcher
+    
+    # Setup Database
+    $DIR/setup_database.py
+
+fi

--- a/setup/setup_database.py
+++ b/setup/setup_database.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-import sqlite3, os, string, hashlib
+import sqlite3, os, string, hashlib, argparse
 from Crypto.Random import random
 
 
@@ -10,11 +10,19 @@ from Crypto.Random import random
 #
 ###################################################
 
+# this is just to set up the ability to call args.
+parser = argparse.ArgumentParser(description="Setup the database for Empire")
+parser.add_argument("-y", "--yes", help="run in non-interactive mode. Say yes to everything", action="store_true", default=False)
+args = parser.parse_args()
+
 # to set a static key used for initial agent staging:
 #   STAGING_KEY = '8q=SDS%l5&Bpf?xIjKL8=Kk2RNwY(f*d'
 
 # otherwise prompt the user for a set value to hash for the negotiation password
-choice = raw_input("\n [>] Enter server negotiation password, enter for random generation: ")
+if not args.yes:
+    choice = raw_input("\n [>] Enter server negotiation password, enter for random generation: ")
+else:
+    choice = ""
 if choice == "":
     # if no password is entered, generation something random
     punctuation = '!#$%&()*+,-./:;<=>?@[\]^_`{|}~'


### PR DESCRIPTION
We've got guys who really like Empire on our pentest team. I'd love to include it in our base install, but it requires a non-interactive installer, which Empire doesn't have.

I re-wrote the install scripts to have a non interactive flag. argparse for python and getopts for bash. Tried to edit your code as little as possible, as I don't want to screw up how you wrote things.

Also noticed an issue where if you run install.sh outside of the directory it's in, you won't get setup_database.py to run because the pathing is relative (or it didn't for me in my scripting). I added something that fixes that, but it does cause an issue if your filename has a space in it. (as a heads up)

Let me know if you think this is something useful.

Krav