### PR TITLE
Made SSL key/cert generation non-interactive

### DIFF
--- a/setup/cert.sh
+++ b/setup/cert.sh
@@ -6,6 +6,7 @@
 #openssl req -new -key ./data/empire.key -out ./data/empire.csr
 #openssl x509 -req -days 365 -in ./data/empire.csr -signkey ./data/empire.key -out ./data/empire.crt
 
-openssl req -new -x509 -keyout ../data/empire.pem -out ../data/empire.pem -days 365 -nodes
+#openssl req -new -x509 -keyout ../data/empire.pem -out ../data/empire.pem -days 365 -nodes
+openssl req -new -x509 -keyout ../data/empire.pem -out ../data/empire.pem -days 365 -nodes -subj "/C=US" >/dev/null 2>&1
 
 echo -e "\n\n [*] Certificate written to ../data/empire.pem\n"


### PR DESCRIPTION
This is my first pull request (anywhere), so please let me know if I did this wrong.  Awesome project!

As you can see, this is a very simple modification.  Just removes the requirement for user input when generating the SSL key/cert by hardcoding the country to US and leaving the other options as default.  I figured this out last year for a project of my own.  

I'm wondering if you delegated the SSL generation to cert.sh because it required interaction.  If that was the reason, you could now include this task in install.sh if you wanted to.  

Demo after change: 
```
root@sethsec:/opt/Empire/setup# ./cert.sh
  [*] Certificate written to ../data/empire.pem
```