### PR TITLE
allow for setup automation

### DIFF
--- a/setup/setup_database.py
+++ b/setup/setup_database.py
@@ -10,17 +10,25 @@ from Crypto.Random import random
 #
 ###################################################
 
-# to set a static key used for initial agent staging:
-#   STAGING_KEY = '8q=SDS%l5&Bpf?xIjKL8=Kk2RNwY(f*d'
+# Staging Key is set up via environmental variable
+# or via command line. By setting RANDOM as random
+# selected password will automatically be selected
+# or it can be set to any bash acceptable
+# character set for a password.
+
+STAGING_KEY = os.getenv('STAGING_KEY', "BLANK")
+punctuation = '!#$%&()*+,-./:;<=>?@[\]^_`{|}~'
 
 # otherwise prompt the user for a set value to hash for the negotiation password
-choice = raw_input("\n [>] Enter server negotiation password, enter for random generation: ")
-if choice == "":
-    # if no password is entered, generation something random
-    punctuation = '!#$%&()*+,-./:;<=>?@[\]^_`{|}~'
+if STAGING_KEY == "BLANK":
+    choice = raw_input("\n [>] Enter server negotiation password, enter for random generation: ")
+    if choice == "":
+        # if no password is entered, generation something random
+        STAGING_KEY = ''.join(random.sample(string.ascii_letters + string.digits + punctuation, 32))
+    else:
+        STAGING_KEY = hashlib.md5(choice).hexdigest()
+elif STAGING_KEY == "RANDOM":
     STAGING_KEY = ''.join(random.sample(string.ascii_letters + string.digits + punctuation, 32))
-else:
-    STAGING_KEY = hashlib.md5(choice).hexdigest()
 
 # the resource requested by the initial launcher
 STAGE0_URI = "index.asp"

--- a/setup/setup_database.py
+++ b/setup/setup_database.py
@@ -11,10 +11,10 @@ from Crypto.Random import random
 ###################################################
 
 # Staging Key is set up via environmental variable
-# or via command line. By setting RANDOM as random
+# or via command line. By setting RANDOM a randomly
 # selected password will automatically be selected
-# or it can be set to any bash acceptable
-# character set for a password.
+# or it can be set to any bash acceptable character
+# set for a password.
 
 STAGING_KEY = os.getenv('STAGING_KEY', "BLANK")
 punctuation = '!#$%&()*+,-./:;<=>?@[\]^_`{|}~'


### PR DESCRIPTION
Does something similar to #83 for non-interactive installation and creation of the database.

Sample run with Install.sh on a Ubuntu 14.04 box
```
~/empire/setup# STAGING_KEY=RANDOM ./install.sh
Reading package lists... Done
Building dependency tree
Reading state information... Done
python-dev is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 3 not upgraded.
Reading package lists... Done
Building dependency tree
Reading state information... Done
python-m2crypto is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 3 not upgraded.
Reading package lists... Done
Building dependency tree
Reading state information... Done
swig is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 3 not upgraded.
Requirement already satisfied (use --upgrade to upgrade): pycrypto in /usr/lib/python2.7/dist-packages
Cleaning up...
Requirement already satisfied (use --upgrade to upgrade): iptools in /usr/local/lib/python2.7/dist-packages
Cleaning up...
Requirement already satisfied (use --upgrade to upgrade): pydispatcher in /usr/local/lib/python2.7/dist-packages
Cleaning up...

 [*] Database setup completed!
 [*] Certificate written to ../data/empire.pem
 [*] Setup complete!
```