### PR TITLE
Add Egress Checking Traffic Generator Module

### DIFF
--- a/data/module_source/exfil/Invoke-EgressCheck.ps1
+++ b/data/module_source/exfil/Invoke-EgressCheck.ps1
@@ -1,0 +1,61 @@
+# Perform the egress check
+function ec {
+    [CmdletBinding()]                                                                                                                                                                           
+    param([string]$ip, [string]$pr) 
+
+    $pr_split = $portrange -split ','
+    $ports = @()
+    foreach ($p in $pr_split) {
+        if ($p -match '^[0-9]+-[0-9]+$') {
+            $prange = $p -split '-'
+            for ($c = [convert]::ToInt32($prange[0]);$c -le [convert]::ToInt32($prange[1]);$c++) {
+                $ports += $c
+            }
+        } elseif ($p -match '^[0-9]+$') {
+            $ports += $p
+        } else {
+            #Error in port definition
+            return
+        }
+    }
+
+    foreach ($eachport in $ports) {
+        Write-Output "Sending TCP/$eachport to $ip"
+		_tcp -ip $ip -port $eachport
+        Write-Output "Sending UDP/$eachport to $ip"
+		_udp -ip $ip -port $eachport
+        Start-Sleep -m (0.2*1000)
+    }
+
+}
+
+# Send the TCP packet async
+function _tcp {
+    [CmdletBinding()]                                                                                                                                                                           
+    param([string]$ip, [int]$port)
+
+	try {                                                                                                                                                                                       
+		$t = New-Object System.Net.Sockets.TCPClient                                                                                                                              
+		$t.BeginConnect($ip, $port, $null, $null) | Out-Null
+        $t.Close()
+        
+	}
+	catch { }  
+}
+
+# Send the UDP packet async
+function _udp {
+    [CmdletBinding()]                                                                                                                                                                           
+    param([string]$ip, [int]$port)
+
+    $d = [system.Text.Encoding]::UTF8.GetBytes(".")
+	try {                                                                                                                                                                                       
+		$t = New-Object System.Net.Sockets.UDPClient       
+        $t.Send($d, $d.Length, $ip, $port) | Out-Null
+        $t.Close()        
+	}
+	catch { }  
+}
+
+# Set the parameters
+ec -ip "192.0.2.1" -pr "20-30,40,50"

--- a/data/module_source/exfil/Invoke-EgressCheck.ps1
+++ b/data/module_source/exfil/Invoke-EgressCheck.ps1
@@ -1,6 +1,6 @@
 <#
 
-This module aims to offer the ability to generate 
+This module aims to offer the ability to generate arbitrary traffic on the ports specified, using the protocol specified.
 Author: Stuart Morgan (@ukstufus)
 Web: https://github.com/stufus
 

--- a/data/module_source/exfil/Invoke-EgressCheck.ps1
+++ b/data/module_source/exfil/Invoke-EgressCheck.ps1
@@ -78,6 +78,8 @@ function Invoke-EgressCheck {
         return
     }
 
+    Write-Output "EgressCheck started"
+
     $pr_split = $portrange -split ','
     foreach ($p in $pr_split) {
         if ($p -match '^[0-9]+-[0-9]+$') {
@@ -97,15 +99,16 @@ function Invoke-EgressCheck {
             return
         }
     }
-    Write-Verbose ""
-
+    Write-Output "EgressCheck completed"
 }
 
 function egress {
     [CmdletBinding()]
     param([string]$ip, [int]$port, [int]$delay, [string]$protocol) 
 
-    if ($protocol -eq "TCP" -Or $protocol -eq "ALL") {
+    $protocol_case = $protocol.ToUpper()
+
+    if ($protocol_case -eq "TCP" -Or $protocol_case -eq "ALL") {
 	    generate_tcp -ip $ip -port $port
         if ($delay -gt 0) {
             Start-Sleep -m ($delay)
@@ -113,11 +116,11 @@ function egress {
         }
      }
 
-    if ($protocol -eq "UDP" -Or $protocol -eq "ALL") {
+    if ($protocol_case -eq "UDP" -Or $protocol_case -eq "ALL") {
 	    generate_udp -ip $ip -port $port
         if ($delay -gt 0) {
             Start-Sleep -m ($delay)
-            Write-Verbose "W/tcp"
+            Write-Verbose "W/udp"
         }
     }
 

--- a/data/module_source/exfil/Invoke-EgressCheck.ps1
+++ b/data/module_source/exfil/Invoke-EgressCheck.ps1
@@ -71,7 +71,7 @@ function Invoke-EgressCheck {
     }
 
     foreach ($eachport in $ports) {
-        if ($protocol.toUpper() -eq 'TCP' -Or $protocol.toUpper() -eq 'ALL') {
+        if ($protocol.toUpper() -eq "TCP" -Or $protocol.toUpper() -eq "ALL") {
 		    generate_tcp -ip $ip -port $eachport -verbosity $verbosity
             if ($delay -gt 0) {
                 Start-Sleep -m ($delay)
@@ -79,7 +79,7 @@ function Invoke-EgressCheck {
             }
         }
 
-        if ($protocol.toUpper() -eq 'UDP' -Or $protocol.toUpper() -eq 'ALL') {
+        if ($protocol.toUpper() -eq "UDP" -Or $protocol.toUpper() -eq "ALL") {
 		    generate_udp -ip $ip -port $eachport -verbosity $verbosity
             if ($delay -gt 0) {
                 Start-Sleep -m ($delay)

--- a/data/module_source/exfil/Invoke-EgressCheck.ps1
+++ b/data/module_source/exfil/Invoke-EgressCheck.ps1
@@ -56,31 +56,36 @@ function Invoke-EgressCheck {
   param([string] $ip, [string] $portrange = "22-25,53,80,443,445,3306,3389", [string] $protocol = "TCP", [int] $verbosity=0, [int] $delay=100)
 
     $pr_split = $portrange -split ','
-    $ports = @()
     foreach ($p in $pr_split) {
         if ($p -match '^[0-9]+-[0-9]+$') {
             $prange = $p -split '-'
             for ($c = [convert]::ToInt32($prange[0]);$c -le [convert]::ToInt32($prange[1]);$c++) {
-                $ports += $c
+                egress -ip $ip -port $c -verbosity $verbosity -delay $delay -protocol $protocol
             }
         } elseif ($p -match '^[0-9]+$') {
-            $ports += $p
+            egress -ip $ip -port $c -verbosity $verbosity -delay $delay -protocol $protocol
         } else {
             return
         }
     }
 
-    foreach ($eachport in $ports) {
-        if ($protocol -eq "TCP" -Or $protocol -eq "ALL") {
-		    generate_tcp -ip $ip -port $eachport -verbosity $verbosity
+}
+
+function egress {
+
+    [CmdletBinding()]
+    param([string]$ip, [int]$port, [int]$verbosity, [int]$delay, [string]$protocol) {
+
+    if ($protocol -eq "TCP" -Or $protocol -eq "ALL") {
+	    generate_tcp -ip $ip -port $port -verbosity $verbosity
             if ($delay -gt 0) {
                 Start-Sleep -m ($delay)
                 if ($verbosity -gt 0) { Write-Host -NoNewLine "W" }
             }
-        }
+     }
 
-        if ($protocol -eq "UDP" -Or $protocol -eq "ALL") {
-		    generate_udp -ip $ip -port $eachport -verbosity $verbosity
+    if ($protocol -eq "UDP" -Or $protocol -eq "ALL") {
+	    generate_udp -ip $ip -port $port -verbosity $verbosity
             if ($delay -gt 0) {
                 Start-Sleep -m ($delay)
                 if ($verbosity -gt 0) { Write-Host -NoNewLine "W" }

--- a/data/module_source/exfil/Invoke-EgressCheck.ps1
+++ b/data/module_source/exfil/Invoke-EgressCheck.ps1
@@ -72,24 +72,22 @@ function Invoke-EgressCheck {
 }
 
 function egress {
-
     [CmdletBinding()]
-    param([string]$ip, [int]$port, [int]$verbosity, [int]$delay, [string]$protocol) {
+    param([string]$ip, [int]$port, [int]$verbosity, [int]$delay, [string]$protocol) 
 
     if ($protocol -eq "TCP" -Or $protocol -eq "ALL") {
 	    generate_tcp -ip $ip -port $port -verbosity $verbosity
-            if ($delay -gt 0) {
-                Start-Sleep -m ($delay)
-                if ($verbosity -gt 0) { Write-Host -NoNewLine "W" }
-            }
+        if ($delay -gt 0) {
+            Start-Sleep -m ($delay)
+            if ($verbosity -gt 0) { Write-Host -NoNewLine "W" }
+        }
      }
 
     if ($protocol -eq "UDP" -Or $protocol -eq "ALL") {
 	    generate_udp -ip $ip -port $port -verbosity $verbosity
-            if ($delay -gt 0) {
-                Start-Sleep -m ($delay)
-                if ($verbosity -gt 0) { Write-Host -NoNewLine "W" }
-            }
+        if ($delay -gt 0) {
+            Start-Sleep -m ($delay)
+            if ($verbosity -gt 0) { Write-Host -NoNewLine "W" }
         }
     }
 

--- a/data/module_source/exfil/Invoke-EgressCheck.ps1
+++ b/data/module_source/exfil/Invoke-EgressCheck.ps1
@@ -62,39 +62,38 @@ function Invoke-EgressCheck {
     }
 
     foreach ($eachport in $ports) {
-        if ($verbose>0) { Write-Host -NoNewLine "t" }
-		_tcp -ip $ip -port $eachport
-        if ($verbose>0) { Write-Host -NoNewLine "t" }
-		_udp -ip $ip -port $eachport
+		generate_tcp -ip $ip -port $eachport -verbose $verbose
+		generate_udp -ip $ip -port $eachport -verbose $verbose
         Start-Sleep -m (0.2*1000)
     }
 
 }
 
 # Send the TCP packet async
-function _tcp {
+function generate_tcp {
     [CmdletBinding()]
-    param([string]$ip, [int]$port)
+    param([string]$ip, [int]$port, [int]$verbose)
 
 	try {
 		$t = New-Object System.Net.Sockets.TCPClient
 		$t.BeginConnect($ip, $port, $null, $null) | Out-Null
         $t.Close()
-
+        if ($verbose>0) { Write-Host -NoNewLine "t" }
 	}
 	catch { }
 }
 
 # Send the UDP packet async
-function _udp {
+function generate_udp {
     [CmdletBinding()]
-    param([string]$ip, [int]$port)
+    param([string]$ip, [int]$port,[int]$verbose)
 
     $d = [system.Text.Encoding]::UTF8.GetBytes(".")
 	try {
 		$t = New-Object System.Net.Sockets.UDPClient
         $t.Send($d, $d.Length, $ip, $port) | Out-Null
         $t.Close()
+        if ($verbose>0) { Write-Host -NoNewLine "u" }
 	}
 	catch { }
 }

--- a/data/module_source/exfil/Invoke-EgressCheck.ps1
+++ b/data/module_source/exfil/Invoke-EgressCheck.ps1
@@ -62,7 +62,7 @@ function Invoke-EgressCheck {
   Default: 100
 
   .EXAMPLE
-  Invoke-EgressCheck -ip 1.2.3.4 -portrange "22-25,53,80,443,445,3306,3389" -protocol ALL -delay 100 -verbosity
+  Invoke-EgressCheck -ip 1.2.3.4 -portrange "22-25,53,80,443,445,3306,3389" -protocol ALL -delay 100 -verbose
 
   .LINK
 

--- a/data/module_source/exfil/Invoke-EgressCheck.ps1
+++ b/data/module_source/exfil/Invoke-EgressCheck.ps1
@@ -1,7 +1,30 @@
-# Perform the egress check
-function ec {
-    [CmdletBinding()]                                                                                                                                                                           
-    param([string]$ip, [string]$pr) 
+function Invoke-EgressCheck {
+  <#  
+  .SYNOPSIS
+
+  Generates traffic on the ports specified, using the protocol specified.
+  This is most useful when attempting to identify breaches in a firewall from
+  an egress perspective.
+
+  A listener on the destination IP address will be required.
+
+  .PARAMETER ip
+
+  The IP address of the target endpoint.
+
+  Example: -ip "10.0.0.1"
+
+  .PARAMETER portrange
+
+  The ports to try. This accepts comma-separated individual port numbers, ranges
+  or both. 
+
+  Example: -portrange "22,23,53,500-1000,1024,1025-1100"
+
+  #>
+
+  [CmdletBinding()]
+  param([string] $ip, [string] $portrange, [string] $protocol) 
 
     $pr_split = $portrange -split ','
     $ports = @()
@@ -14,7 +37,6 @@ function ec {
         } elseif ($p -match '^[0-9]+$') {
             $ports += $p
         } else {
-            #Error in port definition
             return
         }
     }
@@ -56,6 +78,3 @@ function _udp {
 	}
 	catch { }  
 }
-
-# Set the parameters
-ec -ip "192.0.2.1" -pr "20-30,40,50"

--- a/data/module_source/exfil/Invoke-EgressCheck.ps1
+++ b/data/module_source/exfil/Invoke-EgressCheck.ps1
@@ -71,19 +71,19 @@ function Invoke-EgressCheck {
     }
 
     foreach ($eachport in $ports) {
-        if ($protocol.toUpper() -eq "TCP" -Or $protocol.toUpper() -eq "ALL") {
+        if ($protocol -eq "TCP" -Or $protocol -eq "ALL") {
 		    generate_tcp -ip $ip -port $eachport -verbosity $verbosity
             if ($delay -gt 0) {
                 Start-Sleep -m ($delay)
-                if ($verbosity>0) { Write-Host -NoNewLine "W" }
+                if ($verbosity -gt 0) { Write-Host -NoNewLine "W" }
             }
         }
 
-        if ($protocol.toUpper() -eq "UDP" -Or $protocol.toUpper() -eq "ALL") {
+        if ($protocol -eq "UDP" -Or $protocol -eq "ALL") {
 		    generate_udp -ip $ip -port $eachport -verbosity $verbosity
             if ($delay -gt 0) {
                 Start-Sleep -m ($delay)
-                if ($verbosity>0) { Write-Host -NoNewLine "W" }
+                if ($verbosity -gt 0) { Write-Host -NoNewLine "W" }
             }
         }
     }
@@ -99,7 +99,7 @@ function generate_tcp {
 		$t = New-Object System.Net.Sockets.TCPClient
 		$t.BeginConnect($ip, $port, $null, $null) | Out-Null
         $t.Close()
-        if ($verbosity>0) { Write-Host -NoNewLine "t" }
+        if ($verbosity -gt 0) { Write-Host -NoNewLine "t" }
 	}
 	catch { }
 }
@@ -114,7 +114,7 @@ function generate_udp {
 		$t = New-Object System.Net.Sockets.UDPClient
         $t.Send($d, $d.Length, $ip, $port) | Out-Null
         $t.Close()
-        if ($verbosity>0) { Write-Host -NoNewLine "u" }
+        if ($verbosity -gt 0) { Write-Host -NoNewLine "u" }
 	}
 	catch { }
 }

--- a/data/module_source/exfil/Invoke-EgressCheck.ps1
+++ b/data/module_source/exfil/Invoke-EgressCheck.ps1
@@ -1,3 +1,11 @@
+<#
+
+This module aims to offer the ability to generate 
+Author: Stuart Morgan (@ukstufus)
+Web: https://github.com/stufus
+
+#>
+
 function Invoke-EgressCheck {
 
   <#
@@ -7,11 +15,14 @@ function Invoke-EgressCheck {
 
   .DESCRIPTION
 
-  This will generate a single packet on each port specified, using the protocol specified.
-  This is most useful when attempting to identify breaches in a firewall from an egress 
-  perspective. Note that it is quite noisy, but it may be appropriate in some situations.
+  This will attempt to asynchronously generate a connection on each port specified, using the 
+  protocol specified, to a target. This is most useful when attempting to identify breaches 
+  in a firewall from an egress perspective. Note that it is quite noisy, but it may be 
+  appropriate in some situations.
 
-  A listener on the destination IP address will be required.
+  A listener on the destination IP address will be required. The EgressChecker tool could
+  be useful for this (accessible at https://github.com/stufus/egresscheck-framework) or any
+  other method of identifying incoming connections will be fine.
 
   .PARAMETER ip
 

--- a/data/module_source/exfil/Invoke-EgressCheck.ps1
+++ b/data/module_source/exfil/Invoke-EgressCheck.ps1
@@ -10,45 +10,38 @@ function Invoke-EgressCheck {
   A listener on the destination IP address will be required.
 
   .PARAMETER ip
-
   The IP address of the target endpoint.
-
   Example: -ip "10.0.0.1"
 
   .PARAMETER portrange
-
   The ports to try. This accepts comma-separated individual port numbers, ranges
   or both.
-
   Example: -portrange "22-25,53,80,443,445,3306,3389"
   Default: "22-25,53,80,443,445,3306,3389"
 
   .PARAMETER protocol
-
   The IP protocol to use. This can be one of TCP, UDP or ALL.
-
   Example: -protocol "TCP"
   Default: TCP
 
   .PARAMETER verbosity
-
   The verbosity of the console output.
   If this is 0, there is no intentional verbosity.
   If this is 1, it will output:
     't' - Sending a TCP packet
     'u' - Sending a UDP packet
     'W' - Waiting (i.e. sleep/delay)
-
   Example: -verbosity 0
   Default: 0
 
   .PARAMETER delay
-
   The delay between sending packets. This injects a delay in milliseconds between
   packets generated on a per-port per-protocol basis. 
-
   Example: -delay 100
   Default: 100
+
+  .EXAMPLE
+    Invoke-EgressCheck -ip 1.2.3.4 -portrange "22-25,53,80,443,445,3306,3389" -protocol ALL -delay 100 -verbosity 0
 
   #>
 

--- a/lib/modules/exfiltration/egresscheck.py
+++ b/lib/modules/exfiltration/egresscheck.py
@@ -13,8 +13,8 @@ class Module:
             'Author': ['@ukstufus'],
 
             # more verbose multi-line description of the module
-            'Description': ('This module will generate traffic on a provided range'
-                            'description line 2'),
+            'Description': ('This module will generate traffic on a provided range of ports '
+                            'and supports both TCP and UDP. Useful to identify direct egress channels.'),
 
             # True if the module needs to run in the background
             'Background' : False,
@@ -34,8 +34,7 @@ class Module:
 
             # list of any references/other comments
             'Comments': [
-                'comment',
-                'http://link/'
+                'https://github.com/stufus/egresscheck-framework'
             ]
         }
 
@@ -64,10 +63,10 @@ class Module:
                 'Required'      :   True,
                 'Value'         :   '22-25,53,80,443,445,3306,3389'
             },
-            'verbosity' : {
-                'Description'   :   'Verbosity of the script. 0 = quiet, 1 = status',
-                'Required'      :   True,
-                'Value'         :   '0'
+            'verbose' : {
+                'Description'   :   'Verbosity of the script. Set to \'true\' to enable verbosity',
+                'Required'      :   False,
+                'Value'         :   '',
             },
             'delay' : {
                 'Description'   :   'Delay, in milliseconds, between ports being tested',

--- a/lib/modules/exfiltration/egresscheck.py
+++ b/lib/modules/exfiltration/egresscheck.py
@@ -53,22 +53,22 @@ class Module:
                 'Description'   :   'Target IP Address',
                 'Required'      :   True,
                 'Value'         :   ''
-            }
+            },
             'protocol' : {
                 'Description'   :   'The protocol to use. This can be TCP or UDP',
                 'Required'      :   True,
                 'Value'         :   'TCP'
-            }
+            },
             'portrange' : {
                 'Description'   :   'The range of ports to connect on. This can be a comma separated list or dash-separated ranges.',
                 'Required'      :   True,
                 'Value'         :   '22-25,53,80,443,445,3306,3389'
-            }
+            },
             'verbosity' : {
                 'Description'   :   'Verbosity of the script. 0 = quiet, 1 = status',
                 'Required'      :   True,
                 'Value'         :   '0'
-            }
+            },
             'delay' : {
                 'Description'   :   'Delay, in milliseconds, between ports being tested',
                 'Required'      :   True,

--- a/lib/modules/exfiltration/egresscheck.py
+++ b/lib/modules/exfiltration/egresscheck.py
@@ -7,13 +7,13 @@ class Module:
         # metadata info about the module, not modified during runtime
         self.info = {
             # name for the module that will appear in module menus
-            'Name': 'Invoke-Something',
+            'Name': 'Invoke-EgressCheck',
 
             # list of one or more authors for the module
-            'Author': ['@yourname'],
+            'Author': ['@ukstufus'],
 
             # more verbose multi-line description of the module
-            'Description': ('description line 1'
+            'Description': ('This module will generate traffic on a provided range'
                             'description line 2'),
 
             # True if the module needs to run in the background
@@ -26,7 +26,8 @@ class Module:
             'NeedsAdmin' : False,
 
             # True if the method doesn't touch disk/is reasonably opsec safe
-            'OpsecSafe' : True,
+            # Disabled - this can be a relatively noisy module but sometimes useful
+            'OpsecSafe' : False,
             
             # The minimum PowerShell version needed for the module to run
             'MinPSVersion' : '2',
@@ -44,7 +45,7 @@ class Module:
             #   value_name : {description, required, default_value}
             'Agent' : {
                 # The 'Agent' option is the only one that MUST be in a module
-                'Description'   :   'Agent to grab a screenshot from.',
+                'Description'   :   'Agent to generate the source traffic on',
                 'Required'      :   True,
                 'Value'         :   ''
             },

--- a/lib/modules/exfiltration/egresscheck.py
+++ b/lib/modules/exfiltration/egresscheck.py
@@ -49,10 +49,30 @@ class Module:
                 'Required'      :   True,
                 'Value'         :   ''
             },
-            'Command' : {
-                'Description'   :   'Command to execute',
+            'ip' : {
+                'Description'   :   'Target IP Address',
                 'Required'      :   True,
-                'Value'         :   'test'
+                'Value'         :   ''
+            }
+            'protocol' : {
+                'Description'   :   'The protocol to use. This can be TCP or UDP',
+                'Required'      :   True,
+                'Value'         :   'TCP'
+            }
+            'portrange' : {
+                'Description'   :   'The range of ports to connect on. This can be a comma separated list or dash-separated ranges.',
+                'Required'      :   True,
+                'Value'         :   '22-25,53,80,443,445,3306,3389'
+            }
+            'verbosity' : {
+                'Description'   :   'Verbosity of the script. 0 = quiet, 1 = status',
+                'Required'      :   True,
+                'Value'         :   '0'
+            }
+            'delay' : {
+                'Description'   :   'Delay, in milliseconds, between ports being tested',
+                'Required'      :   True,
+                'Value'         :   '100'
             }
         }
 
@@ -73,24 +93,10 @@ class Module:
 
 
     def generate(self):
-        
-        # the PowerShell script itself, with the command to invoke
-        #   for execution appended to the end. Scripts should output
-        #   everything to the pipeline for proper parsing.
-        #
-        # the script should be stripped of comments, with a link to any
-        #   original reference script included in the comments.
-        script = """
-function Invoke-Something {
-    
-}
-Invoke-Something"""
-
-
         # if you're reading in a large, external script that might be updates,
         #   use the pattern below
         # read in the common module source code
-        moduleSource = self.mainMenu.installPath + "/data/module_source/..."
+        moduleSource = self.mainMenu.installPath + "/data/module_source/exfil/Invoke-EgressCheck.ps1"
         try:
             f = open(moduleSource, 'r')
         except:

--- a/lib/modules/exfiltration/egresscheck.py
+++ b/lib/modules/exfiltration/egresscheck.py
@@ -108,6 +108,8 @@ class Module:
 
         script = moduleCode
 
+        # Need to actually run the module that has been loaded
+        script += 'Invoke-EgressCheck'
 
         # add any arguments to the end execution of the script
         for option,values in self.options.iteritems():
@@ -117,6 +119,6 @@ class Module:
                         # if we're just adding a switch
                         script += " -" + str(option)
                     else:
-                        script += " -" + str(option) + " " + str(values['Value'])
+                        script += " -" + str(option) + " \"" + str(values['Value']) + "\""
 
         return script

--- a/lib/modules/exfiltration/egresscheck.py
+++ b/lib/modules/exfiltration/egresscheck.py
@@ -10,7 +10,7 @@ class Module:
             'Name': 'Invoke-EgressCheck',
 
             # list of one or more authors for the module
-            'Author': ['@ukstufus'],
+            'Author': ['Stuart Morgan <stuart.morgan@mwrinfosecurity.com>'],
 
             # more verbose multi-line description of the module
             'Description': ('This module will generate traffic on a provided range of ports '

--- a/lib/modules/exfiltration/egresscheck.py
+++ b/lib/modules/exfiltration/egresscheck.py
@@ -63,15 +63,10 @@ class Module:
                 'Required'      :   True,
                 'Value'         :   '22-25,53,80,443,445,3306,3389'
             },
-            'verbose' : {
-                'Description'   :   'Verbosity of the script. Set to \'true\' to enable verbosity',
-                'Required'      :   False,
-                'Value'         :   '',
-            },
             'delay' : {
                 'Description'   :   'Delay, in milliseconds, between ports being tested',
                 'Required'      :   True,
-                'Value'         :   '100'
+                'Value'         :   '50'
             }
         }
 

--- a/lib/modules/exfiltration/egresscheck.py
+++ b/lib/modules/exfiltration/egresscheck.py
@@ -1,0 +1,115 @@
+from lib.common import helpers
+
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'Invoke-Something',
+
+            # list of one or more authors for the module
+            'Author': ['@yourname'],
+
+            # more verbose multi-line description of the module
+            'Description': ('description line 1'
+                            'description line 2'),
+
+            # True if the module needs to run in the background
+            'Background' : False,
+
+            # File extension to save the file as
+            'OutputExtension' : None,
+
+            # True if the module needs admin rights to run
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : True,
+            
+            # The minimum PowerShell version needed for the module to run
+            'MinPSVersion' : '2',
+
+            # list of any references/other comments
+            'Comments': [
+                'comment',
+                'http://link/'
+            ]
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description'   :   'Agent to grab a screenshot from.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'Command' : {
+                'Description'   :   'Command to execute',
+                'Required'      :   True,
+                'Value'         :   'test'
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+
+    def generate(self):
+        
+        # the PowerShell script itself, with the command to invoke
+        #   for execution appended to the end. Scripts should output
+        #   everything to the pipeline for proper parsing.
+        #
+        # the script should be stripped of comments, with a link to any
+        #   original reference script included in the comments.
+        script = """
+function Invoke-Something {
+    
+}
+Invoke-Something"""
+
+
+        # if you're reading in a large, external script that might be updates,
+        #   use the pattern below
+        # read in the common module source code
+        moduleSource = self.mainMenu.installPath + "/data/module_source/..."
+        try:
+            f = open(moduleSource, 'r')
+        except:
+            print helpers.color("[!] Could not read module source path at: " + str(moduleSource))
+            return ""
+
+        moduleCode = f.read()
+        f.close()
+
+        script = moduleCode
+
+
+        # add any arguments to the end execution of the script
+        for option,values in self.options.iteritems():
+            if option.lower() != "agent":
+                if values['Value'] and values['Value'] != '':
+                    if values['Value'].lower() == "true":
+                        # if we're just adding a switch
+                        script += " -" + str(option)
+                    else:
+                        script += " -" + str(option) + " " + str(values['Value'])
+
+        return script


### PR DESCRIPTION
# Overview

This PR is for a module which will generate a large number of TCP and/or UDP connections to a given target on a specified port range. The main use case is an attempt to bruteforce egress opportunities (e.g. due to firewall misconfigurations) between the compromised host and another host under your control. 

# Background

I designed it with https://github.com/stufus/egresscheck-framework in mind, but any target listener would of course be absolutely fine. The specific details and background can be found at https://github.com/stufus/egresscheck-framework/blob/master/README.md and this module is more or less the powershell equivalent of https://github.com/rapid7/metasploit-framework/pull/6296. 

# Example

```
(Empire: exfiltration/egresscheck) > info

           Name: Invoke-EgressCheck
         Module: exfiltration/egresscheck
     NeedsAdmin: False
      OpsecSafe: False
   MinPSVersion: 2
     Background: False
OutputExtension: None

Authors:
  Stuart Morgan <stuart.morgan@mwrinfosecurity.com>

Description:
  This module will generate traffic on a provided range of
  ports and supports both TCP and UDP. Useful to identify
  direct egress channels.

Options:

  Name             Required    Value                     Description
  ----             --------    -------                   -----------
  delay            True        50                        Delay, in milliseconds, between ports   
                                                         being tested                            
  ip               True                                  Target IP Address                       
  protocol         True        TCP                       The protocol to use. This can be TCP or 
                                                         UDP                                     
  Agent            True                                  Agent to generate the source traffic on 
  portrange        True        22-25,53,80,443,445,3306  The range of ports to connect on. This  
                               ,3389                     can be a comma separated list or dash-  
                                                         separated ranges.                       

(Empire: exfiltration/egresscheck) > set ip 192.0.2.129
(Empire: exfiltration/egresscheck) > set Agent WXWUBKKNLBXRZATC
(Empire: exfiltration/egresscheck) > set protocol ALL
(Empire: exfiltration/egresscheck) > options

           Name: Invoke-EgressCheck
         Module: exfiltration/egresscheck
     NeedsAdmin: False
      OpsecSafe: False
   MinPSVersion: 2
     Background: False
OutputExtension: None

Authors:
  Stuart Morgan <stuart.morgan@mwrinfosecurity.com>

Description:
  This module will generate traffic on a provided range of
  ports and supports both TCP and UDP. Useful to identify
  direct egress channels.

Options:

  Name             Required    Value                     Description
  ----             --------    -------                   -----------
  delay            True        50                        Delay, in milliseconds, between ports   
                                                         being tested                            
  ip               True        192.0.2.129               Target IP Address                       
  protocol         True        ALL                       The protocol to use. This can be TCP or 
                                                         UDP                                     
  Agent            True        WXWUBKKNLBXRZATC          Agent to generate the source traffic on 
  portrange        True        22-25,53,80,443,445,3306  The range of ports to connect on. This  
                               ,3389                     can be a comma separated list or dash-  
                                                         separated ranges.                       

(Empire: exfiltration/egresscheck) > run
[>] Module is not opsec safe, run? [y/N] y
(Empire: exfiltration/egresscheck) > 
EgressCheck started
EgressCheck completed

(Empire: exfiltration/egresscheck) >
```
The screenshot below shows the packet capture on ```192.0.2.129```:
![empire_packet_capture](https://cloud.githubusercontent.com/assets/12296344/11943604/f428b5da-a836-11e5-8613-b62ade96901f.png)

--

Please let me know what I need to fix for this to get landed :-)