### PR TITLE
Identify Managed AD Security Groups

### DIFF
--- a/data/module_source/situational_awareness/network/powerview.ps1
+++ b/data/module_source/situational_awareness/network/powerview.ps1
@@ -11214,6 +11214,17 @@ function Invoke-FindManagedSecurityGroups {
 
         Store a list of all security groups with managers in group-managers.csv
 
+    .DESCRIPTION
+
+        Authority to manipulate the group membership of AD security groups and distribution groups 
+        can be delegated to non-administrators by setting the 'managedBy' attribute. This is typically
+        used to delegate management authority to distribution groups, but Windows supports security groups
+        being managed in the same way.
+
+        This function searches for AD groups which have a group manager set, and determines whether that
+        user can manipulate group membership. This could be a useful method of horizontal privilege
+        escalation, especially if the manager can manipulate the membership of a privileged group.
+
     .LINK
 
         https://github.com/PowerShellEmpire/Empire/pull/119

--- a/data/module_source/situational_awareness/network/powerview.ps1
+++ b/data/module_source/situational_awareness/network/powerview.ps1
@@ -11197,7 +11197,7 @@ function Invoke-MapDomainTrust {
     }
 }
 
-function Invoke-FindManagedSecurityGroups {
+function Find-ManagedSecurityGroups {
 <#
     .SYNOPSIS
 
@@ -11210,7 +11210,7 @@ function Invoke-FindManagedSecurityGroups {
 
     .EXAMPLE
 
-        PS C:\> Invoke-FindManagedSecurityGroups | Export-PowerViewCSV -NoTypeInformation group-managers.csv
+        PS C:\> Find-ManagedSecurityGroups | Export-PowerViewCSV -NoTypeInformation group-managers.csv
 
         Store a list of all security groups with managers in group-managers.csv
 

--- a/data/module_source/situational_awareness/network/powerview.ps1
+++ b/data/module_source/situational_awareness/network/powerview.ps1
@@ -8991,6 +8991,18 @@ function Invoke-EventHunter {
     }
 }
 
+function Invoke-FindManagedSecurityGroups {
+<#
+    .SYNOPSIS
+
+        This function uses ADSI to search for security groups with a manager set.
+
+        Author: Stuart Morgan <stuart.morgan@mwrinfosecurity.com>
+        License: BSD 3-Clause
+#>
+
+}
+
 
 function Invoke-ShareFinder {
 <#

--- a/data/module_source/situational_awareness/network/powerview.ps1
+++ b/data/module_source/situational_awareness/network/powerview.ps1
@@ -9012,6 +9012,21 @@ PS Z:\Empire\data\module_source\situational_awareness\network> $ntsd = $Computer
 PS Z:\Empire\data\module_source\situational_awareness\network>
 PS Z:\Empire\data\module_source\situational_awareness\network> $ntsd
 }
+PS Z:\Empire\data\module_source\situational_awareness\network> $gs.ObjectSecurity.getaccessrules($True,$true,[system.sec
+urity.principal.securityidentifier]) | where {($_.identityreference -eq $cn) -and ($_.objecttype -eq "bf9679c0-0de6-11d0
+-a285-00aa003049e2") -and ($_.accesscontroltype -eq "allow") -and ($_.activedirectoryrights -eq "writeproperty")}
+
+
+ActiveDirectoryRights : WriteProperty
+InheritanceType       : None
+ObjectType            : bf9679c0-0de6-11d0-a285-00aa003049e2
+InheritedObjectType   : 00000000-0000-0000-0000-000000000000
+ObjectFlags           : ObjectAceTypePresent
+AccessControlType     : Allow
+IdentityReference     : S-1-5-21-3412564525-2340160142-3008032522-1127
+IsInherited           : False
+InheritanceFlags      : None
+PropagationFlags      : None
 
 
 function Invoke-ShareFinder {

--- a/data/module_source/situational_awareness/network/powerview.ps1
+++ b/data/module_source/situational_awareness/network/powerview.ps1
@@ -11214,6 +11214,10 @@ function Invoke-FindManagedSecurityGroups {
 
         Store a list of all security groups with managers in group-managers.csv
 
+    .LINK
+
+        https://github.com/PowerShellEmpire/Empire/pull/119
+
 #>
 
     # Go through the list of security groups on the domain and identify those who have a manager

--- a/data/module_source/situational_awareness/network/powerview.ps1
+++ b/data/module_source/situational_awareness/network/powerview.ps1
@@ -11242,9 +11242,10 @@ function Invoke-FindManagedSecurityGroups {
 
         # Find the ACLs that relate to the ability to write to the group
         $xacl = Get-ObjectAcl -ADSPath $_.distinguishedname -Rights WriteMembers
+        $xacl
 
         # Double-check that the manager
-        if ($xacl.ObjectType -eq 'bf9679c0-0de6-11d0-a285-00aa003049e2' -and $xacl.AccessControlType -eq 'Allow' -and $xacl.IdentityReference.Value.Contains($group_manager.cn)) {
+        if ($xacl.ObjectType -eq 'bf9679c0-0de6-11d0-a285-00aa003049e2' -and $xacl.AccessControlType -eq 'Allow' -and $xacl.IdentityReference.Value.Contains($group_manager.samaccountname)) {
             $results_object.CanManagerWrite = $TRUE
         }
 

--- a/data/module_source/situational_awareness/network/powerview.ps1
+++ b/data/module_source/situational_awareness/network/powerview.ps1
@@ -11242,7 +11242,6 @@ function Invoke-FindManagedSecurityGroups {
 
         # Find the ACLs that relate to the ability to write to the group
         $xacl = Get-ObjectAcl -ADSPath $_.distinguishedname -Rights WriteMembers
-        $xacl
 
         # Double-check that the manager
         if ($xacl.ObjectType -eq 'bf9679c0-0de6-11d0-a285-00aa003049e2' -and $xacl.AccessControlType -eq 'Allow' -and $xacl.IdentityReference.Value.Contains($group_manager.samaccountname)) {

--- a/data/module_source/situational_awareness/network/powerview.ps1
+++ b/data/module_source/situational_awareness/network/powerview.ps1
@@ -9001,6 +9001,16 @@ function Invoke-FindManagedSecurityGroups {
         License: BSD 3-Clause
 #>
 
+# $Computer = [ADSI](([ADSISearcher]"(&(objectClass=group)(managedBy=*))"))
+# $Computer.PsBase
+# PS Z:\Empire\data\module_source\situational_awareness\network> $Computer = [ADSI](([ADSISearcher]"(&(objectClass=group)(managedBy=*))").FindOne().Path)
+# PS Z:\Empire\data\module_source\situational_awareness\network> $Computer.PsBase.Properties.nTSecurityDescriptor
+System.__ComObject
+PS Z:\Empire\data\module_source\situational_awareness\network> $Computer = [ADSI](([ADSISearcher]"(&(objectClass=group)(
+managedBy=*))").FindOne().Path)
+PS Z:\Empire\data\module_source\situational_awareness\network> $ntsd = $Computer.PsBase.Properties.nTSecurityDescriptor
+PS Z:\Empire\data\module_source\situational_awareness\network>
+PS Z:\Empire\data\module_source\situational_awareness\network> $ntsd
 }
 
 


### PR DESCRIPTION
# Overview

This function identifies AD groups which have the 'managedBy' attribute set (which will be the DN of a user who is allowed to manage the group) and is based on my initial msf module (https://github.com/rapid7/metasploit-framework/pull/6375). 

AD groups can be managed by otherwise low privileged users by setting the 'Managed By' attribute:

![managed_by_tab](https://cloud.githubusercontent.com/assets/12296344/11920337/03377940-a764-11e5-952d-1ef8184238e0.png)

This is routinely used for distribution groups, but it turns out that security groups also support this option. If the 'manager can update membership list' option is set, it allows that user to add members to the group. This has two implications:

1. If your user happens to be the manager of a group with this option set, you can add yourself or any other user to the group. 
2. You could maintain Domain Admins persistence by setting the Domain Admins group (or any group which is also a member of the Domain Admins group) to be managed by your user. You would then have the ability to gain domain administrator privileges whenever you wished to acquire them.

This module is concerned with Implication 1; identifying AD groups which have a manager set. 

# Explanation of Impact

On a test domain (goat.stu), an unprivileged user has been created with default privileges. As can be seen, this user does not have sufficient privileges to manipulate the domain admins group.

![unprivileged_user](https://cloud.githubusercontent.com/assets/12296344/11920380/5994ea74-a765-11e5-9782-1ff96aaede62.png)

However, if a domain admin user sets the unprivileged user to be the manager of the Domain Admins group and sets the 'Manager can update membership list' option:

![domain_admin_set_managed](https://cloud.githubusercontent.com/assets/12296344/11920390/e3d3cebc-a765-11e5-8909-f72681b6b3e4.png)

The function now returns an object showing the presence of a managed group:

```
PS C:\> Invoke-FindManagedSecurityGroups 

GroupDN         : CN=Domain Admins,CN=Users,DC=goat,DC=stu
ManagerDN       : CN=Unprivileged User,CN=Users,DC=goat,DC=stu
CanManagerWrite : True
ManagerCN       : Unprivileged User
ManagerType     : User
GroupCN         : Domain Admins
ManagerSAN      : unprivileged.user
```

![manipulated_groups](https://cloud.githubusercontent.com/assets/12296344/11920402/5c36a30c-a766-11e5-8898-907f6c646562.png)


# Returned Object

Name | Description
--------|----------------
GroupDN | The distinguished name of the group
ManagerDN | The distinguished name of the manager of the group
CanManagerWrite | Either TRUE or FALSE; if the 'Manager can update membership list', it will be TRUE.
GroupCN | The common name of the group
ManagerSAN | The sAMAccountName (i.e. username) of the manager of the group

This then allows the unprivileged.user to add themselves (or any other user) to the Domain Admins group.

# Conclusion

This function is not likely to be regularly used, but could reveal an otherwise hidden horizontal privilege escalation vulnerability. It is unusual for groups to be managed by non-domain admins but is not unheard of.