### PR TITLE
Download chunk size

### DIFF
--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -1562,7 +1562,7 @@ class AgentMenu(cmd.Cmd):
 
 
     def do_download(self,line):
-        "Task an agent to download a file."
+        "Task an agent to download a file 'download filename [chunk size in KB]'"
 
         line = line.strip()
 


### PR DESCRIPTION
Hi,
It's just a proposal ;-).
The chunk size for download is hard coded to 512KB and sometimes the value needs to be changed. It could be passed as an argument to the download function.
A better way would be to have a global value in the listener function, but that would involve in a lot of changes, so here is the simple not-so-dirty way ;-)
The following code has been tested and i'm currently using it.
Regards.