### PR TITLE
No need for elevated

### DIFF
--- a/lib/modules/credentials/mimikatz/extract_tickets.py
+++ b/lib/modules/credentials/mimikatz/extract_tickets.py
@@ -16,7 +16,7 @@ class Module:
 
             'OutputExtension' : None,
             
-            'NeedsAdmin' : True,
+            'NeedsAdmin' : False,
 
             'OpsecSafe' : True,
 


### PR DESCRIPTION
You don't need elevation to extract kerberos tickets