### PR TITLE
Simple enhancements to installation script to allow unattended installation

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -17,29 +17,29 @@ if lsb_release -d | grep -q "Fedora"; then
 	pip install flask
 elif lsb_release -d | grep -q "Kali"; then
 	Release=Kali
-	apt-get install python-dev
-	apt-get install python-m2crypto
-	apt-get install swig
-	apt-get install python-pip
+	apt-get install -y python-dev
+	apt-get install -y python-m2crypto
+	apt-get install -y swig
+	apt-get install -y python-pip
 	pip install pycrypto
 	pip install iptools
 	pip install pydispatcher
 	pip install flask
 elif lsb_release -d | grep -q "Ubuntu"; then
 	Release=Ubuntu
-	apt-get install python-dev
-	apt-get install python-m2crypto
-	apt-get install swig
-	apt-get install python-pip
+	apt-get install -y python-dev
+	apt-get install -y python-m2crypto
+	apt-get install -y swig
+	apt-get install -y python-pip
 	pip install pycrypto
 	pip install iptools
 	pip install pydispatcher
 	pip install flask
 else
 	echo "Unknown distro - Debian/Ubuntu Fallback"
-	 apt-get install python-dev
-	 apt-get install python-m2crypto
-	 apt-get install swig
+	 apt-get install -y python-dev
+	 apt-get install -y python-m2crypto
+	 apt-get install -y swig
 	 pip install pycrypto
 	 pip install iptools
 	 pip install pydispatcher


### PR DESCRIPTION
Simply added a few "-y" flags to the "apt-get" commands  in order to allow installation without user interaction. This will be especially useful if someone would like to Dockerize Empire (which I would like to do next).

These are insanely negligible changes, but feedback is welcome regardless. Thanks so much for all of y'alls hard work on this! 

--Andrew