### PR TITLE
REST API doesn't start; generating stager fails with REST API call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ data/empire.db
 empire.debug
 *.pyc
 downloads/*
+
+data/empire.pem

--- a/empire
+++ b/empire
@@ -325,6 +325,31 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
             # otherwise return the text of the stager generation
             stagerOut['Output'] = stager.generate()
 
+	stagerOutput = stagerOut['Output']
+        savePath = ''
+        if 'OutFile' in stager.options:
+            savePath = stager.options['OutFile']['Value']
+
+        if savePath != '':
+            # make the base directory if it doesn't exist
+            if not os.path.exists(os.path.dirname(savePath)) and os.path.dirname(savePath) != '':
+                os.makedirs(os.path.dirname(savePath))
+
+            # if we need to write binary output for a .dll
+            if ".dll" in savePath:
+                f = open(savePath, 'wb')
+                f.write(bytearray(stagerOutput))
+                f.close()
+            else:
+                # otherwise normal output
+                f = open(savePath, 'w')
+                f.write(stagerOutput)
+                f.close()
+
+            # if this is a bash script, make it executable
+            if ".sh" in savePath:
+                os.chmod(savePath, 777)
+
         return jsonify({stagerName: stagerOut})
 
 
@@ -1160,7 +1185,7 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
 
     # wrap the Flask connection in SSL and start it
     context = ('./data/empire.pem', './data/empire.pem')
-    app.run(host='0.0.0.0', port=port, ssl_context=context, threaded=True)
+    app.run(host='0.0.0.0', port=int(port), ssl_context=context, threaded=True)
 
 
 


### PR DESCRIPTION
The REST API won’t start due to a bug:

./empire --rest --username "emp" --password "emp"

[*] Loading modules from: /mnt/hgfs/cjones/Empire/lib/modules/
* Starting Empire RESTful API on port: 1337
* RESTful API token: 2bjmeuwa6pr6yy4x0n88rauyyl1nve7cekdgkefh
Traceback (most recent call last):
File "/usr/lib/python2.7/logging/__init__.py", line 853, in emit
msg = self.format(record)
File "/usr/lib/python2.7/logging/__init__.py", line 726, in format
return fmt.format(record)
File "/usr/lib/python2.7/logging/__init__.py", line 465, in format
record.message = record.getMessage()
File "/usr/lib/python2.7/logging/__init__.py", line 329, in getMessage
msg = msg % self.args
TypeError: %d format: a number is required, not str
Logged from file _internal.py, line 87

After casting the port from a string to an int, the REST service works.

Also, when calling the API to create a stager, the .dll is not actually
written to disk.