### PR TITLE
Cast port from string to int when starting REST service

### DIFF
--- a/empire
+++ b/empire
@@ -1182,7 +1182,7 @@ def start_restful_api(startEmpire=False, suppress=False, username=None, password
 
     # wrap the Flask connection in SSL and start it
     context = ('./data/empire.pem', './data/empire.pem')
-    app.run(host='0.0.0.0', port=port, ssl_context=context, threaded=True)
+    app.run(host='0.0.0.0', port=int(port), ssl_context=context, threaded=True)
 
 
 


### PR DESCRIPTION
The REST API won’t start due to a bug:

<code>./empire --rest --username "emp" --password "emp"

[*] Loading modules from: /mnt/hgfs/cjones/Empire/lib/modules/

Starting Empire RESTful API on port: 1337
RESTful API token: 2bjmeuwa6pr6yy4x0n88rauyyl1nve7cekdgkefh Traceback
(most recent call last): File "/usr/lib/python2.7/logging/init.py",
line 853, in emit msg = self.format(record) File
"/usr/lib/python2.7/logging/init.py", line 726, in format return
fmt.format(record) File "/usr/lib/python2.7/logging/init.py", line 465,
in format record.message = record.getMessage() File
"/usr/lib/python2.7/logging/init.py", line 329, in getMessage msg = msg
% self.args TypeError: %d format: a number is required, not str Logged
from file _internal.py, line 87 </code>

After casting the port from a string to an int, the REST service works.