### PR TITLE
Fixed typo

### DIFF
--- a/lib/modules/credentials/mimikatz/dcsync_hashdump.py
+++ b/lib/modules/credentials/mimikatz/dcsync_hashdump.py
@@ -92,7 +92,7 @@ class Module:
         script += "Invoke-DCSync -PWDumpFormat "
 
         if self.options["Domain"]['Value'] != '':
-            script += " -Domain " + self.options['domain']['Value']
+            script += " -Domain " + self.options['Domain']['Value']
 
         if self.options["Forest"]['Value'] != '':
             script += " -DumpForest "


### PR DESCRIPTION
Hi

This just fixes a typo in in dcsync_hashdump that was causing an exception when specifying a domain.