### PR TITLE
Windows port forwarding enable in case of disable

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,8 @@
+3/31/2016
+---------
+-Updated mimikatz dlls to version 2.1 alpha
+-Included modification to suppress cmd.exe when spawned via PTH.
+
 1/17/2016
 ---------
 - '--debug 2' now displays debug information to the console as well as the empire.debug file

--- a/lib/modules/management/redirector.py
+++ b/lib/modules/management/redirector.py
@@ -135,7 +135,11 @@ function Invoke-Redirector {
                 $ConnectPort = $parts[2]
             }
             if($ConnectPort -ne ""){
-            
+           	if ((Get-Service iphlpsvc).Status -ne "Running")
+		{
+			Set-Service iphlpsvc -StartupType manual
+			Start-Service iphlpsvc
+		} 
                 $out = netsh interface portproxy add v4tov4 listenport=$ListenPort connectaddress=$ConnectAddress connectport=$ConnectPort protocol=tcp
                 if($out){
                     $out


### PR DESCRIPTION
The service iphlpsvc is needed for creating routing policies with the netsh module.
The pull request added the simple check and enable for the service start.