### PR TITLE
adding python-pip to unknown deb and moved apt-get commands to one line

### DIFF
--- a/setup/install.sh
+++ b/setup/install.sh
@@ -17,29 +17,21 @@ if lsb_release -d | grep -q "Fedora"; then
 	pip install flask
 elif lsb_release -d | grep -q "Kali"; then
 	Release=Kali
-	apt-get install -y python-dev
-	apt-get install -y python-m2crypto
-	apt-get install -y swig
-	apt-get install -y python-pip
+	apt-get install -y python-dev python-m2crypto swig python-pip
 	pip install pycrypto
 	pip install iptools
 	pip install pydispatcher
 	pip install flask
 elif lsb_release -d | grep -q "Ubuntu"; then
 	Release=Ubuntu
-	apt-get install -y python-dev
-	apt-get install -y python-m2crypto
-	apt-get install -y swig
-	apt-get install -y python-pip
+	apt-get install -y python-dev python-m2crypto swig python-pip
 	pip install pycrypto
 	pip install iptools
 	pip install pydispatcher
 	pip install flask
 else
 	echo "Unknown distro - Debian/Ubuntu Fallback"
-	 apt-get install -y python-dev
-	 apt-get install -y python-m2crypto
-	 apt-get install -y swig
+	 apt-get install -y python-dev python-m2crypto swig python-pip
 	 pip install pycrypto
 	 pip install iptools
 	 pip install pydispatcher


### PR DESCRIPTION
Ran into a situation where python-pip wasn't installed on a deb based box, so I've added python-pip to the unknown section of the install script.

Also moved the various apt-get install commands to just one line so it's a bit cleaner.