### PR TITLE
ArpScanning with reflection

### DIFF
--- a/data/module_source/situational_awareness/network/Invoke-ARPScan.ps1
+++ b/data/module_source/situational_awareness/network/Invoke-ARPScan.ps1
@@ -119,49 +119,36 @@ https://github.com/darkoperator/Posh-SecMod/blob/master/Discovery/Discovery.psm1
             New-IPv4Range $StartIP $EndIP
         }
 
-$sign = @"
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Net;
-using System.Net.NetworkInformation;
-using System.Runtime.InteropServices;
-public static class NetUtils
-{
-    [System.Runtime.InteropServices.DllImport("iphlpapi.dll", ExactSpelling = true)]
-    static extern int SendARP(int DestIP, int SrcIP, byte[] pMacAddr, ref int PhyAddrLen);
-    public static string GetMacAddress(String addr)
-    {
-        try
-                {                   
-                    IPAddress IPaddr = IPAddress.Parse(addr);
-                   
-                    byte[] mac = new byte[6];
-                    
-                    int L = 6;
-                    
-                    SendARP(BitConverter.ToInt32(IPaddr.GetAddressBytes(), 0), 0, mac, ref L);
-                    
-                    String macAddr = BitConverter.ToString(mac, 0, L);
-                    
-                    return (macAddr.Replace('-',':'));
-                }
-                catch (Exception ex)
-                {
-                    return (ex.Message);              
-                }
-    }
-}
-"@
-        try
-        {
-            Write-Verbose "Instanciating NetUtils"
-            $IPHlp = Add-Type -TypeDefinition $sign -Language CSharp -PassThru
-        }
-        catch
-        {
-            Write-Verbose "NetUtils already instanciated"
-        }
+#https://blogs.technet.microsoft.com/heyscriptingguy/2013/06/27/use-powershell-to-interact-with-the-windows-api-part-3/
+$DynAssembly = New-Object System.Reflection.AssemblyName('Win32Lib')
+$AssemblyBuilder = [AppDomain]::CurrentDomain.DefineDynamicAssembly($DynAssembly, [Reflection.Emit.AssemblyBuilderAccess]::Run)
+$ModuleBuilder = $AssemblyBuilder.DefineDynamicModule('Win32Lib', $False)
+$TypeBuilder = $ModuleBuilder.DefineType('IPHlp', 'Public, Class')
+
+$PInvokeMethod = $TypeBuilder.DefineMethod(
+    'SendARP',
+    [Reflection.MethodAttributes] 'Public, Static',
+    [int],
+    [Type[]] @( [int], [int], [byte[]], [int].MakeByRefType() )
+)
+$DllImportConstructor = [Runtime.InteropServices.DllImportAttribute].GetConstructor(@([String]))
+$FieldArray = [Reflection.FieldInfo[]] @(
+        [Runtime.InteropServices.DllImportAttribute].GetField('EntryPoint'),
+        [Runtime.InteropServices.DllImportAttribute].GetField('ExactSpelling')
+)
+$FieldValueArray = [Object[]] @(
+        'SendARP',
+        $True
+)
+$SetLastErrorCustomAttribute = New-Object Reflection.Emit.CustomAttributeBuilder(
+    $DllImportConstructor,
+    @('iphlpapi.dll'),
+    $FieldArray,
+    $FieldValueArray
+)
+$PInvokeMethod.SetCustomAttribute($SetLastErrorCustomAttribute)
+$IPHlp = $TypeBuilder.CreateType()
+
 
         # Manage if range is given
         if ($Range)
@@ -182,8 +169,12 @@ public static class NetUtils
 
         $scancode = {
             param($IPAddress,$IPHlp)
-            $result = $IPHlp::GetMacAddress($IPAddress)
-            if ($result) {New-Object psobject -Property @{Address = $IPAddress; MAC = $result}}
+            $ip = [byte[]]$IPAddress.split('.')
+            $mac = New-Object byte[] 6
+            $lenMac = 6
+            $null = $IPHlp::SendARP( [System.BitConverter]::ToInt32($ip,0), 0, $mac ,[ref] $lenMac)
+            $macStr = [System.BitConverter]::ToString($mac,0,$lenMac).Replace('-',':')
+            if ($macStr) {New-Object psobject -Property @{Address = $IPAddress; MAC = $macStr}}
         } # end ScanCode var
 
         $jobs = @()


### PR DESCRIPTION
c# code was removed and dll importation is made using powershell reflection in order to avoid creating temporary files on disk.