### PR TITLE
Make message more clear when deleting all agents.

### DIFF
--- a/lib/common/agents.py
+++ b/lib/common/agents.py
@@ -203,7 +203,10 @@ class Agents:
             cur.close()
 
             # dispatch this event
-            message = "[*] Agent {} deleted".format(sessionID)
+            if sessionID == '%':
+                message = "[*] All agents deleted"
+            else:
+                message = "[*] Agent {} deleted".format(sessionID)
             signal = json.dumps({
                 'print': True,
                 'message': message


### PR DESCRIPTION
"Agent % deleted" is confusing to some new users.  This displays "All agents deleted" instead.