### PR TITLE
Fixed: using non-local variable.

### DIFF
--- a/data/module_source/management/Invoke-PSInject.ps1
+++ b/data/module_source/management/Invoke-PSInject.ps1
@@ -112,7 +112,7 @@ Param(
         write-verbose "replacestart: $replacestart"
         write-verbose "replaceend: $replaceend"
 
-        $NewCode=[System.Text.Encoding]::Unicode.GetString($RawBytes[$replacestart..$replaceend])
+        $NewCode=[System.Text.Encoding]::Unicode.GetString($DllBytes[$replacestart..$replaceend])
         write-verbose "Replaced pattern with: $NewCode"
         
         return $DllBytes


### PR DESCRIPTION
Bug was invisible because function Invoke-PatchDll is called only once with $RawBytes as $DllBytes parameter. So the local variable $DllBytes and the non-local variable $RawBytes hold the same data.