### PR TITLE
Fix for docker and windows/macroless_msword

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update && apt-get install -qy \
     curl \
     git \
     sudo \
+    zip \
     apt-utils \
     lsb-core \
     python2.7 \


### PR DESCRIPTION
When using docker, the windows/macroless_msword stager cannot generated the final document because the zip utility is missing from the base docker image. 

Fix is in the pull request, just add zip as a dependency.