### PR TITLE
Set sys.argv from the macho template

### DIFF
--- a/data/misc/templateSource/macho.m
+++ b/data/misc/templateSource/macho.m
@@ -14,6 +14,7 @@ int main(int argc, const char * argv[]) {
     setlocale(LC_ALL, "en_US.URF-8");
     Py_SetProgramName(argv[0]);
     Py_Initialize();
+    PySys_SetArgv(argc, argv);
     PyRun_SimpleString(command);
     
     Py_Finalize();


### PR DESCRIPTION
When running an agent in a macho binary, we have an issue where any modules that make use of `sys.argv` (directly or indirectly through dependencies) fail because `sys.argv` hasn't been set. We get the following error:

![image](https://user-images.githubusercontent.com/28896/65730896-dfa9a080-e106-11e9-8f37-bb86f4eea15d.png)

If this same module is run from a python one-liner the error doesn't appear.

This PR attempts to fix this problem by changing the template so that `argc` and `argv` are passed to Python before the agent is run. From here, any references to `sys.argv` should not result in failure.

*Note:* I have not compiled this code (no current access to OSX), but I think it should just work out of the box.