### PR TITLE
Updated string.letters to string.ascii_letters for Python3 - 

### DIFF
--- a/lib/stagers/windows/macro.py
+++ b/lib/stagers/windows/macro.py
@@ -97,8 +97,8 @@ class Stager:
 
         # generate the launcher code
         launcher = self.mainMenu.stagers.generate_launcher(listenerName, language=language, encode=True, obfuscate=obfuscateScript, obfuscationCommand=obfuscateCommand, userAgent=userAgent, proxy=proxy, proxyCreds=proxyCreds, stagerRetries=stagerRetries)
-        Str = ''.join(random.choice(string.letters) for i in range(random.randint(1,len(listenerName))))
-        Method=''.join(random.choice(string.letters) for i in range(random.randint(1,len(listenerName))))
+        Str = ''.join(random.choice(string.ascii_letters) for i in range(random.randint(1,len(listenerName))))
+        Method=''.join(random.choice(string.ascii_letters) for i in range(random.randint(1,len(listenerName))))
 
         if launcher == "":
             print helpers.color("[!] Error in launcher command generation.")


### PR DESCRIPTION
The generating macro module doesn't work because Python3 does not have `string.letters` because it has been renamed to `string.ascii_letters`

https://docs.python.org/2/library/string.html